### PR TITLE
ad-replacement: support size-based creative selection & safeguard against sites that block injected ads

### DIFF
--- a/src/chrome/android/java/res/xml/main_preferences.xml
+++ b/src/chrome/android/java/res/xml/main_preferences.xml
@@ -12,10 +12,10 @@ found in the LICENSE file.
     <org.chromium.chrome.browser.sync.settings.SyncPromoPreference
         android:key="sync_promo"
         android:order="0"/>
-    <PreferenceCategory
+    <!-- <PreferenceCategory
         android:key="account_and_google_services_section"
         android:order="1"
-        android:title="@string/prefs_section_account_and_google_services"/>
+        android:title="@string/prefs_section_account_and_google_services"/> -->
     <org.chromium.chrome.browser.sync.settings.SignInPreference
         android:key="sign_in"
         android:order="2"
@@ -25,7 +25,7 @@ found in the LICENSE file.
         android:order="3"
         android:layout="@layout/account_management_account_row"
         android:title="@string/sync_category_title"/>
-    <org.chromium.components.browser_ui.settings.ChromeBasePreference
+    <!-- <org.chromium.components.browser_ui.settings.ChromeBasePreference
         android:key="google_services"
         android:order="4"
         android:layout="@layout/account_management_account_row"
@@ -36,7 +36,7 @@ found in the LICENSE file.
     <PreferenceCategory
         android:key="basics_section"
         android:order="5"
-        android:title="@string/prefs_section_basics"/>
+        android:title="@string/prefs_section_basics"/> -->
     <org.chromium.components.browser_ui.settings.ChromeBasePreference
         android:fragment="org.chromium.chrome.browser.search_engines.settings.SearchEngineSettings"
         android:key="search_engine"

--- a/src/chrome/android/java/src/org/chromium/chrome/browser/document/ChromeLauncherActivity.java
+++ b/src/chrome/android/java/src/org/chromium/chrome/browser/document/ChromeLauncherActivity.java
@@ -11,6 +11,7 @@ import android.util.Log;
 import com.google.android.material.color.DynamicColors;
 
 import org.chromium.chrome.browser.firstrun.FirstRunActivity;
+import org.chromium.chrome.browser.firstrun.FirstRunStatus;
 import org.chromium.base.TraceEvent;
 import org.chromium.chrome.browser.LaunchIntentDispatcher;
 
@@ -25,6 +26,10 @@ public class ChromeLauncherActivity extends Activity {
         TraceEvent.begin("ChromeLauncherActivity.onCreate");
         super.onCreate(savedInstanceState);
         Log.e("ChromeLauncherActivity", "onCreate");
+
+        // Skip welcome page
+        FirstRunStatus.setSkipWelcomePage(true);
+
         // Handle Branch intents by redirecting to first run experience
         if (getIntent() != null && getIntent().getData() != null 
                 && "branch.wootz.app".equals(getIntent().getData().getHost())) {

--- a/src/chrome/android/java/src/org/chromium/chrome/browser/sync/settings/GoogleServicesSettings.java
+++ b/src/chrome/android/java/src/org/chromium/chrome/browser/sync/settings/GoogleServicesSettings.java
@@ -113,14 +113,17 @@ public class GoogleServicesSettings extends ChromeBaseSettingsFragment
 
         mAllowSignin = (ChromeSwitchPreference) findPreference(PREF_ALLOW_SIGNIN);
 
-        if (getProfile().isChild()) {
-            // Do not display option to allow / disallow sign-in for supervised accounts since
-            // these require the user to be signed-in and syncing.
-            mAllowSignin.setVisible(false);
-        } else {
-            mAllowSignin.setOnPreferenceChangeListener(this);
-            mAllowSignin.setManagedPreferenceDelegate(mManagedPreferenceDelegate);
-        }
+        // if (getProfile().isChild()) {
+        //     // Do not display option to allow / disallow sign-in for supervised accounts since
+        //     // these require the user to be signed-in and syncing.
+        //     mAllowSignin.setVisible(false);
+        // } else {
+        //     mAllowSignin.setOnPreferenceChangeListener(this);
+        //     mAllowSignin.setManagedPreferenceDelegate(mManagedPreferenceDelegate);
+        // }
+
+        mAllowSignin.setVisible(false);
+        
 
         mPasswordsAccountStorage =
                 (ChromeSwitchPreference) findPreference(PREF_PASSWORDS_ACCOUNT_STORAGE);

--- a/src/chrome/browser/first_run/android/java/src/org/chromium/chrome/browser/firstrun/FirstRunStatus.java
+++ b/src/chrome/browser/first_run/android/java/src/org/chromium/chrome/browser/firstrun/FirstRunStatus.java
@@ -67,7 +67,7 @@ public class FirstRunStatus {
     /** Checks whether the welcome page should be skipped from the main First Run Experience. */
     public static boolean shouldSkipWelcomePage() {
         return ChromeSharedPreferences.getInstance()
-                .readBoolean(ChromePreferenceKeys.FIRST_RUN_SKIP_WELCOME_PAGE, false);
+                .readBoolean(ChromePreferenceKeys.FIRST_RUN_SKIP_WELCOME_PAGE, true);
     }
 
     /**

--- a/src/components/signin/internal/identity_manager/primary_account_manager.cc
+++ b/src/components/signin/internal/identity_manager/primary_account_manager.cc
@@ -247,7 +247,7 @@ void PrimaryAccountManager::RegisterProfilePrefs(PrefRegistrySimple* registry) {
       prefs::kGoogleServicesSyncingUsernameMigratedToSignedIn, std::string());
   registry->RegisterBooleanPref(prefs::kAutologinEnabled, true);
   registry->RegisterListPref(prefs::kReverseAutologinRejectedEmailList);
-  registry->RegisterBooleanPref(prefs::kSigninAllowed, true);
+  registry->RegisterBooleanPref(prefs::kSigninAllowed, false);
   registry->RegisterBooleanPref(prefs::kSignedInWithCredentialProvider, false);
   registry->RegisterBooleanPref(kExplicitBrowserSigninWithoutFeatureEnabled,
                                 false);


### PR DESCRIPTION
## 🚀 What’s new

### Size-aware ad replacement
- `processAdElements()` now passes each blocked element’s `[width, height]` to JS.  
- `pickBest()` chooses the closest GPT creative size, then locks the container with `wootzappLockMinSize()` to prevent layout shift.

### Protection against anti-replacement counter-measures
- Adds an early-exit guard (`shouldReplaceBlockedAds`) and a two-pass injection flow that retries when a site hides or rewrites our slot.  
- Pre-connects to `securepubads.g.doubleclick.net` so GPT loads before publisher scripts can interfere.

---

## 🛠️ Implementation highlights
- **`SubresourceFilterAgent`** updated to collect dimensions and schedule JS injection only when replacement is enabled.  
- JS snippet extended with **size map JSON**, smart fallback, and hard-coded CSS to freeze the slot.  
- New log lines show dimension pick-list for easier debugging.

---

## ✅ Testing
- indiatoday.com  
- timesofindia.com  
- hindustantimes.com  

---

## ⚠️ Known limitations
A handful of publishers (e.g., **cnn**) still run late-loading scripts that mutate or remove our injected ad nodes.


___

### **PR Type**
Enhancement


___

### **Description**
- Add size-aware ad replacement with dimension-based creative selection

- Implement protection against sites blocking injected ads

- Add two-pass injection flow with retry mechanism

- Enhance GPT script loading with pre-connection and timing improvements


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Blocked Ad Element"] --> B["Extract Dimensions"]
  B --> C["Size-based Creative Selection"]
  C --> D["Lock Container Size"]
  D --> E["Inject GPT Script"]
  E --> F["Two-pass Protection"]
  F --> G["Display Replacement Ad"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>subresource_filter_agent.cc</strong><dd><code>Size-aware ad replacement with anti-blocking protection</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/components/subresource_filter/content/renderer/subresource_filter_agent.cc

<ul><li>Add dimension extraction and size-based creative selection logic<br> <li> Implement <code>shouldReplaceBlockedAds()</code> guard function for early exit<br> <li> Add <code>processAdElements()</code> to handle element modification with dimensions<br> <li> Introduce <code>pickBest()</code> JavaScript function for optimal creative size <br>matching<br> <li> Add style protection mechanism to prevent third-party interference<br> <li> Implement two-pass injection flow with retry logic<br> <li> Add specialized betting ads detection in <code>FindStaticBettingAds()</code><br> <li> Enhance GPT script loading with onload callback timing</ul>


</details>


  </td>
  <td><a href="https://github.com/wootzapp/wootz-browser/pull/339/files#diff-6be69b24eb7147b51462da0be0509bc7598fb18f7b71c2ccc7593a7c972906fd">+283/-100</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>subresource_filter_agent.h</strong><dd><code>Header updates for size-aware ad replacement methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/subresource_filter/content/renderer/subresource_filter_agent.h

<ul><li>Add new method declarations for dimension handling<br> <li> Add <code>shouldReplaceBlockedAds()</code>, <code>processAdElements()</code>, <code>modifyAdElement()</code> <br>methods<br> <li> Add <code>getElementDimensions()</code> and <code>getElementsDimensionJSON()</code> helper <br>methods<br> <li> Add <code>FindStaticBettingAds()</code> method for specialized ad detection<br> <li> Reorganize method declarations for better code structure</ul>


</details>


  </td>
  <td><a href="https://github.com/wootzapp/wootz-browser/pull/339/files#diff-3cae3bd5debc9ca7d2de9c6ff9cf6b81f20bb0bf1c0b2d7acfcfc9430f915fd7">+33/-26</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

