### PR TITLE
Fix Initial Tab Freeze During Search

### DIFF
--- a/src/chrome/android/java/src/org/chromium/chrome/browser/ChromeTabbedActivity.java
+++ b/src/chrome/android/java/src/org/chromium/chrome/browser/ChromeTabbedActivity.java
@@ -4146,6 +4146,7 @@ public class ChromeTabbedActivity extends ChromeActivity<ChromeActivityComponent
                 }
                 // Mark first run as completed
                 SharedPreferences.Editor editor = prefs.edit();
+                editor.putString("utm_source_wootzapp", extUtmSource);
                 editor.putBoolean("is_first_run", false);
                 editor.apply();
             }

--- a/src/chrome/android/java/src/org/chromium/chrome/browser/firstrun/FirstRunActivity.java
+++ b/src/chrome/android/java/src/org/chromium/chrome/browser/firstrun/FirstRunActivity.java
@@ -413,40 +413,7 @@ public class FirstRunActivity extends FirstRunActivityBase implements FirstRunPa
     @Override
     public void onStart() {
         super.onStart();
-        
-        // // // Get the latest Branch deep link data in onStart
-        Branch.sessionBuilder(this)
-            .withCallback(new Branch.BranchReferralInitListener() {
-                @Override
-                public void onInitFinished(JSONObject referringParams, BranchError error) {
-                    if (error == null && referringParams != null) {
-                        Log.e(TAG, "onFirstRunActivityStart: Branch session data: " + referringParams.toString());
-                        try {
-                            android.content.SharedPreferences prefs = getSharedPreferences("branch_data", MODE_PRIVATE);
-                            android.content.SharedPreferences.Editor editor = prefs.edit();
 
-                            // Store the full JSON for reference
-                            editor.putString("branch_data_json", referringParams.toString());
-
-                            // Store individual parameters
-                            if (referringParams.has("~channel")) {
-                                String utmSource = referringParams.optString("~campaign", "");
-                                editor.putString("utm_source_wootzapp", utmSource);
-                                Log.e(TAG, "Stored utm_source_wootzapp: " + utmSource);
-                            }
-                            editor.apply();
-                            Log.e(TAG, "Branch data stored in SharedPreferences");
-                        } catch (Exception e) {
-                            Log.e(TAG, "Error storing branch data: " + e.getMessage(), e);
-                        }
-                    } else if (error != null) {
-                        Log.e(TAG, "onFirstRunActivityStart: Branch initialization error: " + error.getMessage());
-                    }
-                }
-            })
-            .withData(getIntent().getData())
-            .init();
-    
         // Multiple active FREs does not really make sense for the user. Once one is complete, the
         // others would become out of date. This approach turns out to be quite tricky to enforce
         // completely with just Android configuration, because of all the different ways the FRE


### PR DESCRIPTION
### **User description**
### Description:
The initial tab was freezing when performing a search because the FirstRunActivity was creating a Branch session in onStart(). This likely caused heavy background processing, leading to UI blocking on the first tab.

### Fix Implemented:

- Removed Branch session initialization from FirstRunActivity.onStart() to prevent unnecessary processing during first tab usage.
- 
- Moved UTM source handling to ChromeTabbedActivity.handleBranchDeepLinkParams() to ensure data is still captured without impacting tab performance.

**Impact:**
This change eliminates the initial tab freeze on search, improving first-run user experience.


___

### **PR Type**
Bug fix


___

### **Description**
- Remove Branch session initialization from FirstRunActivity to fix tab freeze

- Move UTM source storage to ChromeTabbedActivity for better performance

- Eliminate UI blocking during first-run search operations


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["FirstRunActivity.onStart()"] -- "Remove" --> B["Branch Session Init"]
  C["ChromeTabbedActivity"] -- "Add" --> D["UTM Source Storage"]
  B -- "Prevents" --> E["Tab Freeze Issue"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ChromeTabbedActivity.java</strong><dd><code>Add UTM source storage to deep link handler</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/chrome/android/java/src/org/chromium/chrome/browser/ChromeTabbedActivity.java

<ul><li>Add UTM source storage to existing Branch deep link handling<br> <li> Store <code>utm_source_wootzapp</code> in SharedPreferences during deep link <br>processing</ul>


</details>


  </td>
  <td><a href="https://github.com/wootzapp/wootz-browser/pull/350/files#diff-8ffad9d01feda1102c2ce85837b62396fc3ad6fd72e36937bc5135ea66618cb1">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>FirstRunActivity.java</strong><dd><code>Remove Branch session initialization from onStart</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/chrome/android/java/src/org/chromium/chrome/browser/firstrun/FirstRunActivity.java

<ul><li>Remove entire Branch session initialization block from <code>onStart()</code> <br>method<br> <li> Eliminate Branch callback listener and SharedPreferences storage logic<br> <li> Remove heavy background processing that caused UI freezing</ul>


</details>


  </td>
  <td><a href="https://github.com/wootzapp/wootz-browser/pull/350/files#diff-967b23fe8aca60709a8af6a146cd667719433b2b060239aeeb5e080c129d689c">+1/-34</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

