### PR TITLE
Disable Google Sign-In and skip FRE welcome

### DIFF
--- a/src/chrome/android/java/res/xml/main_preferences.xml
+++ b/src/chrome/android/java/res/xml/main_preferences.xml
@@ -12,10 +12,10 @@ found in the LICENSE file.
     <org.chromium.chrome.browser.sync.settings.SyncPromoPreference
         android:key="sync_promo"
         android:order="0"/>
-    <PreferenceCategory
+    <!-- <PreferenceCategory
         android:key="account_and_google_services_section"
         android:order="1"
-        android:title="@string/prefs_section_account_and_google_services"/>
+        android:title="@string/prefs_section_account_and_google_services"/> -->
     <org.chromium.chrome.browser.sync.settings.SignInPreference
         android:key="sign_in"
         android:order="2"
@@ -25,7 +25,7 @@ found in the LICENSE file.
         android:order="3"
         android:layout="@layout/account_management_account_row"
         android:title="@string/sync_category_title"/>
-    <org.chromium.components.browser_ui.settings.ChromeBasePreference
+    <!-- <org.chromium.components.browser_ui.settings.ChromeBasePreference
         android:key="google_services"
         android:order="4"
         android:layout="@layout/account_management_account_row"
@@ -36,7 +36,7 @@ found in the LICENSE file.
     <PreferenceCategory
         android:key="basics_section"
         android:order="5"
-        android:title="@string/prefs_section_basics"/>
+        android:title="@string/prefs_section_basics"/> -->
     <org.chromium.components.browser_ui.settings.ChromeBasePreference
         android:fragment="org.chromium.chrome.browser.search_engines.settings.SearchEngineSettings"
         android:key="search_engine"

--- a/src/chrome/android/java/src/org/chromium/chrome/browser/document/ChromeLauncherActivity.java
+++ b/src/chrome/android/java/src/org/chromium/chrome/browser/document/ChromeLauncherActivity.java
@@ -11,6 +11,7 @@ import android.util.Log;
 import com.google.android.material.color.DynamicColors;
 
 import org.chromium.chrome.browser.firstrun.FirstRunActivity;
+import org.chromium.chrome.browser.firstrun.FirstRunStatus;
 import org.chromium.base.TraceEvent;
 import org.chromium.chrome.browser.LaunchIntentDispatcher;
 
@@ -25,6 +26,10 @@ public class ChromeLauncherActivity extends Activity {
         TraceEvent.begin("ChromeLauncherActivity.onCreate");
         super.onCreate(savedInstanceState);
         Log.e("ChromeLauncherActivity", "onCreate");
+
+        // Skip welcome page
+        FirstRunStatus.setSkipWelcomePage(true);
+
         // Handle Branch intents by redirecting to first run experience
         if (getIntent() != null && getIntent().getData() != null 
                 && "branch.wootz.app".equals(getIntent().getData().getHost())) {

--- a/src/chrome/android/java/src/org/chromium/chrome/browser/sync/settings/GoogleServicesSettings.java
+++ b/src/chrome/android/java/src/org/chromium/chrome/browser/sync/settings/GoogleServicesSettings.java
@@ -113,14 +113,17 @@ public class GoogleServicesSettings extends ChromeBaseSettingsFragment
 
         mAllowSignin = (ChromeSwitchPreference) findPreference(PREF_ALLOW_SIGNIN);
 
-        if (getProfile().isChild()) {
-            // Do not display option to allow / disallow sign-in for supervised accounts since
-            // these require the user to be signed-in and syncing.
-            mAllowSignin.setVisible(false);
-        } else {
-            mAllowSignin.setOnPreferenceChangeListener(this);
-            mAllowSignin.setManagedPreferenceDelegate(mManagedPreferenceDelegate);
-        }
+        // if (getProfile().isChild()) {
+        //     // Do not display option to allow / disallow sign-in for supervised accounts since
+        //     // these require the user to be signed-in and syncing.
+        //     mAllowSignin.setVisible(false);
+        // } else {
+        //     mAllowSignin.setOnPreferenceChangeListener(this);
+        //     mAllowSignin.setManagedPreferenceDelegate(mManagedPreferenceDelegate);
+        // }
+
+        mAllowSignin.setVisible(false);
+        
 
         mPasswordsAccountStorage =
                 (ChromeSwitchPreference) findPreference(PREF_PASSWORDS_ACCOUNT_STORAGE);

--- a/src/chrome/browser/first_run/android/java/src/org/chromium/chrome/browser/firstrun/FirstRunStatus.java
+++ b/src/chrome/browser/first_run/android/java/src/org/chromium/chrome/browser/firstrun/FirstRunStatus.java
@@ -67,7 +67,7 @@ public class FirstRunStatus {
     /** Checks whether the welcome page should be skipped from the main First Run Experience. */
     public static boolean shouldSkipWelcomePage() {
         return ChromeSharedPreferences.getInstance()
-                .readBoolean(ChromePreferenceKeys.FIRST_RUN_SKIP_WELCOME_PAGE, false);
+                .readBoolean(ChromePreferenceKeys.FIRST_RUN_SKIP_WELCOME_PAGE, true);
     }
 
     /**

--- a/src/components/signin/internal/identity_manager/primary_account_manager.cc
+++ b/src/components/signin/internal/identity_manager/primary_account_manager.cc
@@ -247,7 +247,7 @@ void PrimaryAccountManager::RegisterProfilePrefs(PrefRegistrySimple* registry) {
       prefs::kGoogleServicesSyncingUsernameMigratedToSignedIn, std::string());
   registry->RegisterBooleanPref(prefs::kAutologinEnabled, true);
   registry->RegisterListPref(prefs::kReverseAutologinRejectedEmailList);
-  registry->RegisterBooleanPref(prefs::kSigninAllowed, true);
+  registry->RegisterBooleanPref(prefs::kSigninAllowed, false);
   registry->RegisterBooleanPref(prefs::kSignedInWithCredentialProvider, false);
   registry->RegisterBooleanPref(kExplicitBrowserSigninWithoutFeatureEnabled,
                                 false);


### PR DESCRIPTION
### **User description**
### Summary
This PR removes all Google sign-in surfaces from our Android build and prevents account sign-in at the prefs level. It also skips the First Run Experience (FRE) welcome page so users are taken straight into the browser.

### What changed (by file)
- **src/chrome/android/java/res/xml/main_preferences.xml**
  - Commented out the “Account & Google services” section, “Google services”, and related entries so account/sync settings no longer appear.

- **src/chrome/android/java/src/org/chromium/chrome/browser/document/ChromeLauncherActivity.java**
  - Added `FirstRunStatus.setSkipWelcomePage(true)` to bypass the welcome screen.

- **src/chrome/android/java/src/org/chromium/chrome/browser/sync/settings/GoogleServicesSettings.java**
  - Hid the “Allow sign-in” toggle (`mAllowSignin.setVisible(false)`), removing the ability to enable sign-in from settings.

- **src/chrome/browser/first_run/android/java/src/org/chromium/chrome/browser/firstrun/FirstRunStatus.java**
  - Default `shouldSkipWelcomePage()` to **true** when unset.

- **src/components/signin/internal/identity_manager/primary_account_manager.cc**
  - Registered `prefs::kSigninAllowed` default as **false**, disabling sign-in at the preference level.

### Behavior after this change
- No Google account prompts or sign-in related UI in Settings.
- FRE welcome page is skipped.
- Sign-in is disabled by default; features requiring an account (Sync, passwords account storage to Google, etc.) won’t be available.

### Risks / considerations
- Disables account-based features (Sync, passwords account storage to account, some personalization).

### Testing done
- Fresh install → app launches directly to the browser (no welcome/sign-in).
- Settings → no “Account & Google services” section or sign-in toggle.
- Attempting flows that previously triggered sign-in no longer surface an account prompt.


___

### **PR Type**
Enhancement


___

### **Description**
- Disable Google sign-in functionality at preference level

- Skip First Run Experience welcome page by default

- Hide sign-in UI elements from settings

- Comment out account-related preferences sections


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["User launches app"] --> B["Skip welcome page"]
  B --> C["Browser main view"]
  D["Settings access"] --> E["No sign-in options"]
  F["Sign-in preference"] --> G["Default: false"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>primary_account_manager.cc</strong><dd><code>Disable sign-in at preference level</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/signin/internal/identity_manager/primary_account_manager.cc

<ul><li>Changed default value of <code>prefs::kSigninAllowed</code> from <code>true</code> to <code>false</code></ul>


</details>


  </td>
  <td><a href="https://github.com/wootzapp/wootz-browser/pull/351/files#diff-a9dd79aa7dfa3430e54d7973ec05e41da73075e4b3e559f99c38266143f4db12">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>FirstRunStatus.java</strong><dd><code>Default welcome page skip to true</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/chrome/browser/first_run/android/java/src/org/chromium/chrome/browser/firstrun/FirstRunStatus.java

<ul><li>Changed default value in <code>shouldSkipWelcomePage()</code> from <code>false</code> to <code>true</code></ul>


</details>


  </td>
  <td><a href="https://github.com/wootzapp/wootz-browser/pull/351/files#diff-7b3469b9de13d7c6db7175dd11200610f214f77b6b604d67137c329b2fae191f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main_preferences.xml</strong><dd><code>Remove account preferences from settings UI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/chrome/android/java/res/xml/main_preferences.xml

<ul><li>Commented out "Account & Google services" preference category<br> <li> Commented out "Google services" preference entry<br> <li> Commented out "Basics" section title</ul>


</details>


  </td>
  <td><a href="https://github.com/wootzapp/wootz-browser/pull/351/files#diff-93483e30c81e34fc0057eeb01e104383e77fe814d793e257026c0cf2eb325e05">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ChromeLauncherActivity.java</strong><dd><code>Skip welcome page on app launch</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/chrome/android/java/src/org/chromium/chrome/browser/document/ChromeLauncherActivity.java

<ul><li>Added import for <code>FirstRunStatus</code><br> <li> Set <code>FirstRunStatus.setSkipWelcomePage(true)</code> in <code>onCreate</code> method</ul>


</details>


  </td>
  <td><a href="https://github.com/wootzapp/wootz-browser/pull/351/files#diff-568325809786f60992e561cebc1e851d040779d76cc610e3f31747acc150ff97">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>GoogleServicesSettings.java</strong><dd><code>Hide sign-in toggle in settings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/chrome/android/java/src/org/chromium/chrome/browser/sync/settings/GoogleServicesSettings.java

<ul><li>Commented out conditional logic for sign-in preference visibility<br> <li> Set <code>mAllowSignin.setVisible(false)</code> to hide sign-in toggle</ul>


</details>


  </td>
  <td><a href="https://github.com/wootzapp/wootz-browser/pull/351/files#diff-5284a91cbbaec5b032ce4b3ae3bb8310e0d73314d577724c4b8e445c2e2fd053">+11/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

