### PR TITLE
Fix screenshot capture crash in Play Store builds

### DIFF
--- a/src/chrome/android/java/src/org/chromium/chrome/browser/extensions/WootzScreenshotApi.java
+++ b/src/chrome/android/java/src/org/chromium/chrome/browser/extensions/WootzScreenshotApi.java
@@ -24,7 +24,6 @@ import java.io.ByteArrayOutputStream;
  * Java implementation of screenshot functionality for Wootz extensions.
  * Captures only the visible viewport for efficiency.
  */
-@JNINamespace("chrome::android")
 public class WootzScreenshotApi {
     private static final String TAG = "WootzScreenshotApi";
     private static final int MAX_VIEWPORT_DIMENSION = 1080; // Reduced to prevent large base64
@@ -32,22 +31,21 @@ public class WootzScreenshotApi {
 
     /**
      * Called from C++ to trigger screenshot capture.
-     * @param nativePtr Pointer to the C++ function object
      */
     @CalledByNative
-    public static void captureScreenshot(long nativePtr) {
+    public static void captureScreenshot() {
         try {
             Activity activity = ApplicationStatus.getLastTrackedFocusedActivity();
             if (activity == null) {
                 Log.e(TAG, "No focused activity found");
-                WootzScreenshotApiJni.get().onScreenshotError(nativePtr, "No focused activity found");
+                WootzScreenshotApiJni.get().onScreenshotError("No focused activity found");
                 return;
             }
 
             // Check if activity is still valid before proceeding
             if (activity.isFinishing() || activity.isDestroyed()) {
                 Log.e(TAG, "Activity not valid - finishing: " + activity.isFinishing() + ", destroyed: " + activity.isDestroyed());
-                WootzScreenshotApiJni.get().onScreenshotError(nativePtr, "Activity not valid");
+                WootzScreenshotApiJni.get().onScreenshotError("Activity not valid");
                 return;
             }
 
@@ -62,16 +60,12 @@ public class WootzScreenshotApi {
 
                         if (!screenshotTask.isReady()) {
                             Log.e(TAG, "ScreenshotTask not ready");
-                            WootzScreenshotApiJni.get().onScreenshotError(nativePtr, "ScreenshotTask not ready");
+                            WootzScreenshotApiJni.get().onScreenshotError("ScreenshotTask not ready");
                             return;
                         }
 
                         Bitmap bitmap = screenshotTask.getScreenshot();
                         if (bitmap != null) {
-                            int[] pixels = new int[Math.min(bitmap.getWidth(), 10) * Math.min(bitmap.getHeight(), 10)];
-                            bitmap.getPixels(pixels, 0, Math.min(bitmap.getWidth(), 10), 0, 0, 
-                                           Math.min(bitmap.getWidth(), 10), Math.min(bitmap.getHeight(), 10));
-
                             // Scale down if too large to reduce memory usage
                             Bitmap scaledBitmap = scaleBitmapIfNeeded(bitmap);
                             if (scaledBitmap != bitmap) {
@@ -80,22 +74,22 @@ public class WootzScreenshotApi {
 
                             // Convert to base64 with compression
                             String base64Data = convertBitmapToBase64Compressed(bitmap);
-                            WootzScreenshotApiJni.get().onScreenshotComplete(nativePtr, base64Data);
+                            WootzScreenshotApiJni.get().onScreenshotComplete(base64Data);
                             return;
                         } else {
                             Log.e(TAG, "ScreenshotTask returned null bitmap");
-                            WootzScreenshotApiJni.get().onScreenshotError(nativePtr, "ScreenshotTask returned null bitmap");
+                            WootzScreenshotApiJni.get().onScreenshotError("ScreenshotTask returned null bitmap");
                         }
                     } catch (Exception e) {
                         Log.e(TAG, "Error in ScreenshotTask callback", e);
-                        WootzScreenshotApiJni.get().onScreenshotError(nativePtr, "Error in ScreenshotTask: " + e.getMessage());
+                        WootzScreenshotApiJni.get().onScreenshotError("Error in ScreenshotTask: " + e.getMessage());
                     }
                 }
             });
 
         } catch (Exception e) {
             Log.e(TAG, "Error creating ScreenshotTask", e);
-            WootzScreenshotApiJni.get().onScreenshotError(nativePtr, "Error creating ScreenshotTask: " + e.getMessage());
+            WootzScreenshotApiJni.get().onScreenshotError("Error creating ScreenshotTask: " + e.getMessage());
         }
     }
 
@@ -151,7 +145,7 @@ public class WootzScreenshotApi {
 
     @NativeMethods
     interface Natives {
-        void onScreenshotComplete(long nativePtr, String base64Data);
-        void onScreenshotError(long nativePtr, String error);
+        void onScreenshotComplete(String base64Data);
+        void onScreenshotError(String error);
     }
 }

--- a/src/chrome/android/java/src/org/chromium/chrome/browser/extensions/WootzScreenshotApi.java
+++ b/src/chrome/android/java/src/org/chromium/chrome/browser/extensions/WootzScreenshotApi.java
@@ -27,7 +27,7 @@ import java.io.ByteArrayOutputStream;
 @JNINamespace("chrome::android")
 public class WootzScreenshotApi {
     private static final String TAG = "WootzScreenshotApi";
-    private static final int MAX_VIEWPORT_DIMENSION = 1000; // Reduced to prevent large base64
+    private static final int MAX_VIEWPORT_DIMENSION = 1080; // Reduced to prevent large base64
     private static final int JPEG_QUALITY = 80; // Reduced quality to prevent large base64
 
     /**
@@ -40,14 +40,14 @@ public class WootzScreenshotApi {
             Activity activity = ApplicationStatus.getLastTrackedFocusedActivity();
             if (activity == null) {
                 Log.e(TAG, "No focused activity found");
-                onScreenshotError(nativePtr, "No focused activity found");
+                WootzScreenshotApiJni.get().onScreenshotError(nativePtr, "No focused activity found");
                 return;
             }
 
             // Check if activity is still valid before proceeding
             if (activity.isFinishing() || activity.isDestroyed()) {
                 Log.e(TAG, "Activity not valid - finishing: " + activity.isFinishing() + ", destroyed: " + activity.isDestroyed());
-                onScreenshotError(nativePtr, "Activity not valid");
+                WootzScreenshotApiJni.get().onScreenshotError(nativePtr, "Activity not valid");
                 return;
             }
 
@@ -62,7 +62,7 @@ public class WootzScreenshotApi {
 
                         if (!screenshotTask.isReady()) {
                             Log.e(TAG, "ScreenshotTask not ready");
-                            onScreenshotError(nativePtr, "ScreenshotTask not ready");
+                            WootzScreenshotApiJni.get().onScreenshotError(nativePtr, "ScreenshotTask not ready");
                             return;
                         }
 
@@ -80,22 +80,22 @@ public class WootzScreenshotApi {
 
                             // Convert to base64 with compression
                             String base64Data = convertBitmapToBase64Compressed(bitmap);
-                            onScreenshotComplete(nativePtr, base64Data);
+                            WootzScreenshotApiJni.get().onScreenshotComplete(nativePtr, base64Data);
                             return;
                         } else {
                             Log.e(TAG, "ScreenshotTask returned null bitmap");
-                            onScreenshotError(nativePtr, "ScreenshotTask returned null bitmap");
+                            WootzScreenshotApiJni.get().onScreenshotError(nativePtr, "ScreenshotTask returned null bitmap");
                         }
                     } catch (Exception e) {
                         Log.e(TAG, "Error in ScreenshotTask callback", e);
-                        onScreenshotError(nativePtr, "Error in ScreenshotTask: " + e.getMessage());
+                        WootzScreenshotApiJni.get().onScreenshotError(nativePtr, "Error in ScreenshotTask: " + e.getMessage());
                     }
                 }
             });
 
         } catch (Exception e) {
             Log.e(TAG, "Error creating ScreenshotTask", e);
-            onScreenshotError(nativePtr, "Error creating ScreenshotTask: " + e.getMessage());
+            WootzScreenshotApiJni.get().onScreenshotError(nativePtr, "Error creating ScreenshotTask: " + e.getMessage());
         }
     }
 
@@ -149,6 +149,9 @@ public class WootzScreenshotApi {
         }
     }
 
-    private static native void onScreenshotComplete(long nativePtr, String base64Data);
-    private static native void onScreenshotError(long nativePtr, String error);
+    @NativeMethods
+    interface Natives {
+        void onScreenshotComplete(long nativePtr, String base64Data);
+        void onScreenshotError(long nativePtr, String error);
+    }
 }

--- a/src/chrome/android/proguard/main.flags
+++ b/src/chrome/android/proguard/main.flags
@@ -46,3 +46,27 @@
 -keep class org.chromium.chrome.browser.extensions.Extensions { *; }
 -keep class org.chromium.chrome.browser.extensions.ExtensionsConfirmationDialog { *; }
 -keep class org.chromium.chrome.browser.extensions.ExtensionInfo { *; }
+
+# Keep WootzScreenshotApi class and its methods to prevent ProGuard obfuscation
+-keep class org.chromium.chrome.browser.extensions.WootzScreenshotApi {
+  public static void captureScreenshot(long);
+  public static class Natives {
+    void onScreenshotComplete(long, java.lang.String);
+    void onScreenshotError(long, java.lang.String);
+  }
+}
+
+# Keep the auto-generated JNI binding class
+-keep class org.chromium.chrome.browser.extensions.WootzScreenshotApiJni {
+  public static *;
+}
+
+# Prevent obfuscation of JNI method names - this is critical for Play Store builds
+-keepclassmembers class org.chromium.chrome.browser.extensions.WootzScreenshotApi {
+  native <methods>;
+}
+
+# Keep all JNI-related classes and methods for WootzScreenshotApi
+-keep class org.chromium.chrome.browser.extensions.WootzScreenshotApi** {
+  *;
+}

--- a/src/chrome/android/proguard/main.flags
+++ b/src/chrome/android/proguard/main.flags
@@ -49,24 +49,14 @@
 
 # Keep WootzScreenshotApi class and its methods to prevent ProGuard obfuscation
 -keep class org.chromium.chrome.browser.extensions.WootzScreenshotApi {
-  public static void captureScreenshot(long);
+  public static void captureScreenshot();
   public static class Natives {
-    void onScreenshotComplete(long, java.lang.String);
-    void onScreenshotError(long, java.lang.String);
+    void onScreenshotComplete(java.lang.String);
+    void onScreenshotError(java.lang.String);
   }
 }
 
 # Keep the auto-generated JNI binding class
 -keep class org.chromium.chrome.browser.extensions.WootzScreenshotApiJni {
   public static *;
-}
-
-# Prevent obfuscation of JNI method names - this is critical for Play Store builds
--keepclassmembers class org.chromium.chrome.browser.extensions.WootzScreenshotApi {
-  native <methods>;
-}
-
-# Keep all JNI-related classes and methods for WootzScreenshotApi
--keep class org.chromium.chrome.browser.extensions.WootzScreenshotApi** {
-  *;
 }

--- a/src/chrome/browser/extensions/api/wootz/wootz_api.cc
+++ b/src/chrome/browser/extensions/api/wootz/wootz_api.cc
@@ -27,8 +27,6 @@
 #include "build/build_config.h"
 #include "chrome/android/chrome_jni_headers/WootzAppBackgroundContentService_jni.h"
 #include "chrome/android/chrome_jni_headers/WootzBridge_jni.h"
-// Define the Ptr alias expected by generated jni header before including it.
-namespace chrome { namespace android { using Ptr = extensions::WootzCaptureScreenshotFunction; } }
 #include "chrome/android/chrome_jni_headers/WootzScreenshotApi_jni.h"
 #include "chrome/browser/extensions/extension_service.h"
 #include "chrome/browser/profiles/profile.h"
@@ -1911,58 +1909,16 @@ ExtensionFunction::ResponseAction WootzCaptureScreenshotFunction::Run() {
     LOG(WARNING) << " Unexpected arguments provided";
   }
 
-  // Add a reference to ensure this object stays alive during the async callback
-  AddRef();
-
   // Trigger screenshot capture via JNI
-  // This will call back to OnScreenshotComplete or OnScreenshotError
   JNIEnv* env = base::android::AttachCurrentThread();
-  chrome::android::Java_WootzScreenshotApi_captureScreenshot(env, reinterpret_cast<jlong>(this));
+  Java_WootzScreenshotApi_captureScreenshot(env);
 
-  return RespondLater();
-}
-
-void WootzCaptureScreenshotFunction::OnScreenshotComplete(const std::string& base64_data) {
-  LOG(INFO) << " Base64 data length: " << base64_data.length();
-
+  // Return success immediately - the actual result will be handled by the event
   base::Value::Dict result;
   result.Set("success", true);
-  result.Set("dataUrl", base64_data);
+  result.Set("message", "Screenshot capture initiated");
 
-  base::Value::List args;
-  args.Append(std::move(result));
-
-  LOG(INFO) << " Responding with success";
-  Respond(ArgumentList(std::move(args)));
-
-  Release();
-}
-
-void WootzCaptureScreenshotFunction::OnScreenshotError(const std::string& error) {
-  LOG(ERROR) << " Error: " << error;
-
-  base::Value::Dict result;
-  result.Set("success", false);
-  result.Set("error", error);
-
-  base::Value::List args;
-  args.Append(std::move(result));
-
-  LOG(INFO) << " Responding with error";
-  Respond(ArgumentList(std::move(args)));
-
-  Release();
-}
-
-// JNI callback functions for screenshot functionality (matching generated header)
-void WootzCaptureScreenshotFunction::OnScreenshotComplete(JNIEnv* env, const base::android::JavaParamRef<jstring>& base64_data) {
-  std::string base64_string = base::android::ConvertJavaStringToUTF8(env, base64_data);
-  OnScreenshotComplete(base64_string);
-}
-
-void WootzCaptureScreenshotFunction::OnScreenshotError(JNIEnv* env, const base::android::JavaParamRef<jstring>& error) {
-  std::string error_string = base::android::ConvertJavaStringToUTF8(env, error);
-  OnScreenshotError(error_string);
+  return RespondNow(WithArguments(std::move(result)));
 }
 
 }  // namespace extensions
@@ -1997,6 +1953,98 @@ void JNI_WootzBridge_OnDropdownButtonClicked(JNIEnv* env, const base::android::J
     return;
   }
   wootz_api->OnDropdownButtonClicked(feature, extId, extName);
+}
+
+
+// Global JNI callback functions 
+void JNI_WootzScreenshotApi_OnScreenshotComplete(JNIEnv* env, const base::android::JavaParamRef<jstring>& base64_data) {
+  std::string base64_string = base::android::ConvertJavaStringToUTF8(env, base64_data);
+  LOG(INFO) << "JNI: Screenshot completed, base64 length: " << base64_string.length();
+  
+  // Dispatch event to all extensions (like WootzBridge pattern)
+  ProfileManager* profile_manager = g_browser_process->profile_manager();
+  if (!profile_manager) {
+    LOG(ERROR) << "JNI: ProfileManager not available";
+    return;
+  }
+  
+  Profile* profile = profile_manager->GetPrimaryUserProfile();
+  if (!profile) {
+    LOG(ERROR) << "JNI: Primary user profile not available";
+    return;
+  }
+  
+  auto* event_router = extensions::EventRouter::Get(profile);
+  if (!event_router) {
+    LOG(ERROR) << "JNI: Event router not available";
+    return;
+  }
+  
+  // Create event data
+  base::Value::List event_args;
+  base::Value::Dict result;
+  result.Set("success", true);
+  result.Set("dataUrl", base64_string);
+  event_args.Append(std::move(result));
+  
+  // Create and dispatch event
+  std::unique_ptr<extensions::Event> event = std::make_unique<extensions::Event>(
+      extensions::events::WOOTZ_ON_SCREENSHOT_COMPLETE,
+      "wootz.onScreenshotComplete",
+      std::move(event_args), 
+      profile,
+      std::nullopt,
+      GURL(), 
+      extensions::EventRouter::USER_GESTURE_UNKNOWN,
+      extensions::mojom::EventFilteringInfo::New());
+  
+  LOG(INFO) << "JNI: Dispatching screenshot complete event";
+  event_router->BroadcastEvent(std::move(event));
+}
+
+void JNI_WootzScreenshotApi_OnScreenshotError(JNIEnv* env, const base::android::JavaParamRef<jstring>& error) {
+  std::string error_string = base::android::ConvertJavaStringToUTF8(env, error);
+  LOG(ERROR) << "JNI: Screenshot error: " << error_string;
+  
+  // Dispatch event to all extensions (like WootzBridge pattern)
+  ProfileManager* profile_manager = g_browser_process->profile_manager();
+  if (!profile_manager) {
+    LOG(ERROR) << "JNI: ProfileManager not available";
+    return;
+  }
+  
+  Profile* profile = profile_manager->GetPrimaryUserProfile();
+  if (!profile) {
+    LOG(ERROR) << "JNI: Primary user profile not available";
+    return;
+  }
+  
+  auto* event_router = extensions::EventRouter::Get(profile);
+  if (!event_router) {
+    LOG(ERROR) << "JNI: Event router not available";
+    return;
+  }
+  
+  // Create event data
+  base::Value::List event_args;
+  base::Value::Dict result;
+  result.Set("success", false);
+  result.Set("error", error_string);
+  event_args.Append(std::move(result));
+  
+  // Create and dispatch event
+  std::unique_ptr<extensions::Event> event = std::make_unique<extensions::Event>(
+      extensions::events::WOOTZ_ON_SCREENSHOT_COMPLETE,
+      "wootz.onScreenshotComplete",
+      std::move(event_args), 
+      profile,
+      std::nullopt,
+      GURL(), 
+      extensions::EventRouter::USER_GESTURE_UNKNOWN,
+      extensions::mojom::EventFilteringInfo::New());
+  
+  LOG(INFO) << "JNI: Dispatching screenshot error event";
+  event_router->BroadcastEvent(std::move(event));
 }
 
 

--- a/src/chrome/browser/extensions/api/wootz/wootz_api.cc
+++ b/src/chrome/browser/extensions/api/wootz/wootz_api.cc
@@ -1954,6 +1954,17 @@ void WootzCaptureScreenshotFunction::OnScreenshotError(const std::string& error)
   Release();
 }
 
+// JNI callback functions for screenshot functionality (matching generated header)
+void WootzCaptureScreenshotFunction::OnScreenshotComplete(JNIEnv* env, const base::android::JavaParamRef<jstring>& base64_data) {
+  std::string base64_string = base::android::ConvertJavaStringToUTF8(env, base64_data);
+  OnScreenshotComplete(base64_string);
+}
+
+void WootzCaptureScreenshotFunction::OnScreenshotError(JNIEnv* env, const base::android::JavaParamRef<jstring>& error) {
+  std::string error_string = base::android::ConvertJavaStringToUTF8(env, error);
+  OnScreenshotError(error_string);
+}
+
 }  // namespace extensions
 
 void JNI_WootzBridge_OnConsentResult(JNIEnv* env, jboolean consented){
@@ -1988,78 +1999,6 @@ void JNI_WootzBridge_OnDropdownButtonClicked(JNIEnv* env, const base::android::J
   wootz_api->OnDropdownButtonClicked(feature, extId, extName);
 }
 
-
-// JNI callback functions for screenshot functionality
-extern "C" JNIEXPORT void JNICALL
-Java_org_chromium_chrome_browser_extensions_WootzScreenshotApi_onScreenshotComplete(
-    JNIEnv* env, jclass clazz, jlong native_ptr, jstring base64_data) {
-  if (native_ptr == 0) {
-    LOG(ERROR) << "native_ptr is null";
-    return;
-  }
-
-  auto* function = reinterpret_cast<extensions::WootzCaptureScreenshotFunction*>(native_ptr);
-  if (!function) {
-    LOG(ERROR) << "Failed to reinterpret_cast native_ptr to WootzCaptureScreenshotFunction";
-    return;
-  }
-
-  std::string base64_string = base::android::ConvertJavaStringToUTF8(env, base64_data);
-
-  // Add a reference to ensure the object stays alive during the callback
-  function->AddRef();
-
-  // Create a scoped_refptr to properly manage the refcounted object
-  scoped_refptr<extensions::WootzCaptureScreenshotFunction> function_ref(function);
-
-  // Post to UI thread to ensure Respond() is called on the correct thread
-  content::GetUIThreadTaskRunner({})->PostTask(
-      FROM_HERE,
-      base::BindOnce(
-        [](scoped_refptr<extensions::WootzCaptureScreenshotFunction> fn,
-           std::string data) {
-          if (fn) {
-            fn->OnScreenshotComplete(data);
-          }
-        },
-        std::move(function_ref), std::move(base64_string)));
-}
-
-extern "C" JNIEXPORT void JNICALL
-Java_org_chromium_chrome_browser_extensions_WootzScreenshotApi_onScreenshotError(
-    JNIEnv* env, jclass clazz, jlong native_ptr, jstring error) {
-
-  if (native_ptr == 0) {
-    LOG(ERROR) << "native_ptr is null";
-    return;
-  }
-
-  auto* function = reinterpret_cast<extensions::WootzCaptureScreenshotFunction*>(native_ptr);
-  if (!function) {
-    LOG(ERROR) << "Failed to reinterpret_cast native_ptr to WootzCaptureScreenshotFunction";
-    return;
-  }
-
-  std::string error_string = base::android::ConvertJavaStringToUTF8(env, error);
-
-  // Add a reference to ensure the object stays alive during the callback
-  function->AddRef();
-
-  // Create a scoped_refptr to properly manage the refcounted object
-  scoped_refptr<extensions::WootzCaptureScreenshotFunction> function_ref(function);
-
-  // Post to UI thread to ensure Respond() is called on the correct thread
-  content::GetUIThreadTaskRunner({})->PostTask(
-      FROM_HERE,
-      base::BindOnce(
-        [](scoped_refptr<extensions::WootzCaptureScreenshotFunction> fn,
-           std::string error_msg) {
-          if (fn) {
-            fn->OnScreenshotError(error_msg);
-          }
-        },
-        std::move(function_ref), std::move(error_string)));
-}
 
 // extern "C" JNIEXPORT void JNICALL
 // Java_org_chromium_chrome_browser_extensions_WootzBridge_nativeOnConsentDialogResult(

--- a/src/chrome/browser/extensions/api/wootz/wootz_api.h
+++ b/src/chrome/browser/extensions/api/wootz/wootz_api.h
@@ -453,28 +453,10 @@ class WootzChangeWootzAppSearchConfigurationFunction : public ExtensionFunction 
 class WootzCaptureScreenshotFunction : public ExtensionFunction {
  public:
   DECLARE_EXTENSION_FUNCTION("wootz.captureScreenshot", WOOTZ_CAPTURE_SCREENSHOT)
+  WootzCaptureScreenshotFunction() = default;
  protected:
   ~WootzCaptureScreenshotFunction() override = default;
   ResponseAction Run() override;
- public:
-  void OnScreenshotComplete(const std::string& base64_data);
-  void OnScreenshotError(const std::string& error);
-  
-  // JNI callback methods (called by generated JNI code)
-  void OnScreenshotComplete(JNIEnv* env, const base::android::JavaParamRef<jstring>& base64_data);
-  void OnScreenshotError(JNIEnv* env, const base::android::JavaParamRef<jstring>& error);
-
-  // Add reference counting to ensure the object stays alive during async callbacks
-  void AddRef() { ref_count_++; }
-  void Release() { 
-    if (--ref_count_ == 0) {
-      delete this;
-    }
-  }
-  int ref_count_ = 0;
-
- private:
-  base::WeakPtrFactory<WootzCaptureScreenshotFunction> weak_factory_{this};
 };
 
 }  // namespace extensions

--- a/src/chrome/browser/extensions/api/wootz/wootz_api.h
+++ b/src/chrome/browser/extensions/api/wootz/wootz_api.h
@@ -459,6 +459,10 @@ class WootzCaptureScreenshotFunction : public ExtensionFunction {
  public:
   void OnScreenshotComplete(const std::string& base64_data);
   void OnScreenshotError(const std::string& error);
+  
+  // JNI callback methods (called by generated JNI code)
+  void OnScreenshotComplete(JNIEnv* env, const base::android::JavaParamRef<jstring>& base64_data);
+  void OnScreenshotError(JNIEnv* env, const base::android::JavaParamRef<jstring>& error);
 
   // Add reference counting to ensure the object stays alive during async callbacks
   void AddRef() { ref_count_++; }

--- a/src/chrome/common/extensions/api/wootz.json
+++ b/src/chrome/common/extensions/api/wootz.json
@@ -866,8 +866,7 @@
                 "type": "object",
                 "properties": {
                   "success": {"type": "boolean", "description": "Whether the screenshot was successful"},
-                  "dataUrl": {"type": "string", "optional": true, "description": "Base64-encoded Jpeg image as data URL"},
-                  "error": {"type": "string", "optional": true, "description": "Error message if screenshot failed"}
+                  "message": {"type": "string", "optional": true, "description": "Message about the screenshot"}
                 }
               }
             ]
@@ -972,6 +971,22 @@
                 "extensionId": {"type": "string", "description": "ID of the target extension"},
                 "extensionName": {"type": "string", "description": "Name of the target extension"},
                 "timestamp": {"type": "number", "description": "When the event occurred"}
+              }
+            }
+          ]
+        },
+        {
+          "name": "onScreenshotComplete",
+          "type": "function",
+          "description": "Fired when a screenshot capture is completed",
+          "parameters": [
+            {
+              "name": "result",
+              "type": "object",
+              "properties": {
+                "success": {"type": "boolean", "description": "Whether the screenshot was successful"},
+                "dataUrl": {"type": "string", "optional": true, "description": "Base64-encoded Jpeg image as data URL"},
+                "error": {"type": "string", "optional": true, "description": "Error message if screenshot failed"}
               }
             }
           ]

--- a/src/extensions/browser/extension_event_histogram_value.h
+++ b/src/extensions/browser/extension_event_histogram_value.h
@@ -582,6 +582,7 @@ enum HistogramValue {
   WOOTZ_ON_TRANSACTION_STATUS_CHANGED = 559,
   WOOTZ_ON_SOLANA_SIGN_TRANSACTION_REQUESTED = 560,
   WOOTZ_ON_DROPDOWN_BUTTON_CLICKED = 561,
+  WOOTZ_ON_SCREENSHOT_COMPLETE = 562,
   
   // Last entry: Add new entries above, then run:
   // tools/metrics/histograms/update_extension_histograms.py


### PR DESCRIPTION
# 🚀 Fix: UnsatisfiedLinkError Crash in Screenshot API

### **User-facing change**

✅ Fixed **`UnsatisfiedLinkError` crash** when capturing screenshots in production builds distributed through the Play Store.

---

## 📖 Description

⛓️‍💥 The issue was caused by:

* **ProGuard obfuscation** breaking JNI method bindings.
* **Incorrect JNI implementation pattern** in the screenshot API.

### 🔧 Fixes

* Updated `WootzScreenshotApi` to use the same proven JNI binding pattern as **WootzBridge**.
* Added **comprehensive ProGuard rules** to prevent obfuscation of critical JNI classes.

---

## 🧪 Testing

🎯 Verified on both **APKs and AABs** across multiple scenarios.

---

## 📌 Usage Example

### 1️⃣ Add a listener

```js
chrome.wootz.onScreenshotComplete.addListener((result) => {
  console.log('Screenshot Result: ', result);
});
```

### 2️⃣ Call `captureScreenshot`

```js
chrome.wootz.captureScreenshot();
```

### 3️⃣ Response Format

```json
{
  "success": {
    "type": "boolean",
    "description": "Whether the screenshot was successful"
  },
  "message": {
    "type": "string",
    "optional": true,
    "description": "Message about the screenshot"
  }
}
```

### 4️⃣ Example Listener Output

```js
{
  dataUrl: "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD…AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB//Z",
  success: true
}
```