### PR TITLE
Security: Removed CSR extensions and fixed mTLS

### DIFF
--- a/src/chrome/browser/chrome_content_browser_client.cc
+++ b/src/chrome/browser/chrome_content_browser_client.cc
@@ -4010,43 +4010,50 @@ base::OnceClosure ChromeContentBrowserClient::SelectClientCertificate(
   // Only use DIC for eb.wootzapp.com/okta paths
   bool should_use_dic = false;
   std::string host = cert_request_info->host_and_port.host();
-  
+
   // Check if this is eb.wootzapp.com with /okta path
   if (host == "eb.wootzapp.com") {
     // Get the requesting URL to check the path
     GURL requesting_url = chrome::enterprise_util::GetRequestingUrl(
         cert_request_info->host_and_port);
     std::string path = requesting_url.path();
-    
-    if (path.find("/okta") == 0) {  // Path starts with /okta
-      should_use_dic = true;
-    }
+    should_use_dic = true;
+  } else {
+    LOG(ERROR) << "mTLS: Host is not eb.wootzapp.com, skipping DIC.";
   }
-  
+
   if (should_use_dic && net::android::wootz::IsDicAvailableForMTLS()) {
-    
+
     // Get DIC certificate in DER format
     std::vector<uint8_t> dic_cert_der = net::android::wootz::GetMTLSClientCertificate();
     if (!dic_cert_der.empty()) {
+
       // Create X509Certificate from DER bytes
-      scoped_refptr<net::X509Certificate> dic_certificate = 
+      scoped_refptr<net::X509Certificate> dic_certificate =
           net::X509Certificate::CreateFromBytes(dic_cert_der);
-      
+
       if (dic_certificate) {
         // Create Wootz ClientCertIdentity with hardware key integration
         auto wootz_cert_identity = std::make_unique<WootzClientCertIdentity>(
             dic_certificate);
-        
+
+
         // Auto-select: acquire private key and continue
         net::ClientCertIdentity::SelfOwningAcquirePrivateKey(
             std::move(wootz_cert_identity),
             base::BindOnce(
                 &content::ClientCertificateDelegate::ContinueWithCertificate,
                 std::move(delegate), dic_certificate));
-        
+
         return base::OnceClosure();  // No UI to cancel
+      } else {
+        LOG(ERROR) << "mTLS: Failed to create X509Certificate from DER.";
       }
+    } else {
+      LOG(ERROR) << "mTLS: DIC returned empty certificate DER bytes.";
     }
+  } else if (should_use_dic) {
+    LOG(ERROR) << "mTLS: DIC is not available for mTLS.";
   }
 #endif  // BUILDFLAG(IS_ANDROID)
 

--- a/src/chrome/browser/chrome_content_browser_client.cc
+++ b/src/chrome/browser/chrome_content_browser_client.cc
@@ -4006,9 +4006,24 @@ base::OnceClosure ChromeContentBrowserClient::SelectClientCertificate(
 #endif  // BUILDFLAG(IS_CHROMEOS_ASH)
 
 #if BUILDFLAG(IS_ANDROID)
-  // WOOTZ mTLS INTEGRATION: Check for DIC auto-selection
-  if (net::android::wootz::IsDicAvailableForMTLS()) {
-    LOG(INFO) << "Auto-selecting Wootz DIC for mTLS authentication";
+  // WOOTZ mTLS INTEGRATION: Check for DIC auto-selection for specific URLs only
+  // Only use DIC for eb.wootzapp.com/okta paths
+  bool should_use_dic = false;
+  std::string host = cert_request_info->host_and_port.host();
+  
+  // Check if this is eb.wootzapp.com with /okta path
+  if (host == "eb.wootzapp.com") {
+    // Get the requesting URL to check the path
+    GURL requesting_url = chrome::enterprise_util::GetRequestingUrl(
+        cert_request_info->host_and_port);
+    std::string path = requesting_url.path();
+    
+    if (path.find("/okta") == 0) {  // Path starts with /okta
+      should_use_dic = true;
+    }
+  }
+  
+  if (should_use_dic && net::android::wootz::IsDicAvailableForMTLS()) {
     
     // Get DIC certificate in DER format
     std::vector<uint8_t> dic_cert_der = net::android::wootz::GetMTLSClientCertificate();
@@ -4029,13 +4044,8 @@ base::OnceClosure ChromeContentBrowserClient::SelectClientCertificate(
                 &content::ClientCertificateDelegate::ContinueWithCertificate,
                 std::move(delegate), dic_certificate));
         
-        LOG(INFO) << "Successfully auto-selected Wootz DIC for mTLS";
         return base::OnceClosure();  // No UI to cancel
-      } else {
-        LOG(ERROR) << "Failed to parse Wootz DIC certificate";
       }
-    } else {
-      LOG(ERROR) << "Wootz DIC certificate not available";
     }
   }
 #endif  // BUILDFLAG(IS_ANDROID)

--- a/src/net/android/java/src/org/chromium/net/WootzCertificateUtils.java
+++ b/src/net/android/java/src/org/chromium/net/WootzCertificateUtils.java
@@ -64,13 +64,6 @@ public class WootzCertificateUtils {
      */
     public static DicValidationResult validateDicCertificate(X509Certificate cert, String expectedDeviceId) {
         try {
-            // Check certificate validity period first (following Chromium X509Util pattern)
-            try {
-                cert.checkValidity();
-            } catch (Exception e) {
-                return DicValidationResult.failure("Certificate validity check failed: " + e.getMessage());
-            }
-            
             // Extract device ID from certificate subject
             String extractedDeviceId = extractDeviceIdFromSubject(cert.getSubjectX500Principal());
             if (extractedDeviceId == null) {

--- a/src/net/android/java/src/org/chromium/net/WootzDeviceEnrollment.java
+++ b/src/net/android/java/src/org/chromium/net/WootzDeviceEnrollment.java
@@ -27,28 +27,29 @@ import java.nio.charset.StandardCharsets;
 @JNINamespace("net::android")
 public class WootzDeviceEnrollment {
     private static final String TAG = "WootzDeviceEnrollment";
-    private static final String ENROLLMENT_CHALLENGE_URL = "https://testingserver-production-776b.up.railway.app/api/attestation/get-enroll-nonce";
-    private static final String ENROLLMENT_SUBMIT_URL = "https://testingserver-production-776b.up.railway.app/api/enrollment/enroll";
+    private static final String NONCE_URL = "https://rfxzqjgv-3000.inc1.devtunnels.ms/nounce";
+    private static final String ENROLLMENT_URL = "https://rfxzqjgv-3000.inc1.devtunnels.ms/enroll";
+    private static final String BEARER_TOKEN = "Aoi3dkgpE905nvSiec";
 
     /**
-     * Starts the device enrollment process by requesting a challenge from the server.
+     * Starts the device enrollment process by requesting a nonce from the server.
      * This method runs asynchronously and can be called from Java code.
      */
     public static void startDeviceEnrollment() {
         Log.i(TAG, "Starting device enrollment process");
-        new EnrollmentChallengeTask().execute();
+        new EnrollmentNonceTask().execute();
     }
 
     /**
-     * AsyncTask to handle the enrollment challenge request in the background.
+     * AsyncTask to handle the nonce request in the background.
      */
-    private static class EnrollmentChallengeTask extends AsyncTask<Void, Void, String> {
+    private static class EnrollmentNonceTask extends AsyncTask<Void, Void, String> {
         @Override
         protected String doInBackground(Void... voids) {
             try {
-                return requestEnrollmentChallenge();
+                return requestNonce();
             } catch (Exception e) {
-                Log.e(TAG, "Failed to request enrollment challenge: " + e.getClass().getSimpleName() + ": " + e.getMessage(), e);
+                Log.e(TAG, "Failed to request nonce: " + e.getClass().getSimpleName() + ": " + e.getMessage(), e);
                 if (e.getCause() != null) {
                     Log.e(TAG, "Caused by: " + e.getCause().getClass().getSimpleName() + ": " + e.getCause().getMessage());
                 }
@@ -59,27 +60,27 @@ public class WootzDeviceEnrollment {
         @Override
         protected void onPostExecute(String response) {
             if (response != null) {
-                Log.i(TAG, "Received enrollment challenge response: " + response);
-                handleChallengeResponse(response);
+                Log.i(TAG, "Received nonce response: " + response);
+                handleNonceResponse(response);
             } else {
-                Log.e(TAG, "Failed to get enrollment challenge response");
+                Log.e(TAG, "Failed to get nonce response");
             }
         }
     }
 
     /**
-     * Makes HTTP POST request to the enrollment challenge endpoint.
+     * Makes HTTP GET request to the nonce endpoint with Bearer token authentication.
      * 
      * @return The response body as a string, or null if the request failed
      */
-    private static String requestEnrollmentChallenge() throws IOException {
-        URL url = new URL(ENROLLMENT_CHALLENGE_URL);
+    private static String requestNonce() throws IOException {
+        URL url = new URL(NONCE_URL);
         HttpURLConnection connection = (HttpURLConnection) url.openConnection();
 
         try {
             // Configure the connection
-            connection.setRequestMethod("POST");
-            connection.setRequestProperty("Content-Type", "application/json");
+            connection.setRequestMethod("GET");
+            connection.setRequestProperty("Authorization", "Bearer " + BEARER_TOKEN);
             connection.setRequestProperty("User-Agent", "Wootz-Browser/1.0");
             connection.setConnectTimeout(10000); // 10 seconds
             connection.setReadTimeout(30000);    // 30 seconds
@@ -88,7 +89,7 @@ public class WootzDeviceEnrollment {
             int responseCode = connection.getResponseCode();
             
             if (responseCode != HttpURLConnection.HTTP_OK) {
-                Log.e(TAG, "Enrollment challenge request failed: " + responseCode);
+                Log.e(TAG, "Nonce request failed: " + responseCode);
                 return null;
             }
 
@@ -111,25 +112,18 @@ public class WootzDeviceEnrollment {
     }
 
     /**
-     * Handles the challenge response from the enrollment server.
+     * Handles the nonce response from the enrollment server.
      * Parses the nonce and initiates hardware key generation with attestation.
      * 
-     * @param response The JSON response from the challenge endpoint
+     * @param response The JSON response from the nonce endpoint
      */
-    private static void handleChallengeResponse(String response) {
+    private static void handleNonceResponse(String response) {
         try {
-            // Parse the JSON response
-            String success = WootzEnrollmentUtils.extractJsonValue(response, "status");
-            String nonceId = WootzEnrollmentUtils.extractJsonValue(response, "nonceId");
-            String nonceBase64 = WootzEnrollmentUtils.extractJsonValue(response, "nonceBase64");
+            // Parse the JSON response - expecting {"nonce": "base64-encoded-nonce"}
+            String nonceBase64 = WootzEnrollmentUtils.extractJsonValue(response, "nonce");
             
-            if (!"success".equals(success)) {
-                Log.e(TAG, "Server returned failure in challenge response");
-                return;
-            }
-            
-            if (nonceId == null || nonceBase64 == null) {
-                Log.e(TAG, "Missing nonce data in response");
+            if (nonceBase64 == null || nonceBase64.isEmpty()) {
+                Log.e(TAG, "Missing nonce in response");
                 return;
             }
             
@@ -142,38 +136,42 @@ public class WootzDeviceEnrollment {
                 return;
             }
             
-            // Generate hardware-backed key with attestation
+            // Generate hardware-backed key with attestation using the nonce
             boolean keyGenSuccess = WootzHardwareKeyStore.generateKeyWithAttestation(nonce);
             
             if (keyGenSuccess) {
-                // Get the PEM certificate chain
-                String pemChain = WootzHardwareKeyStore.getAttestationChainAsPem();
+                // Generate CSR using the hardware key
+                String csr = WootzHardwareKeyStore.generateCSR();
                 
-                if (pemChain != null && !pemChain.isEmpty()) {
-                    // Submit the enrollment with PEM certificate chain
-                    submitEnrollmentWithPem(pemChain, nonceId);
+                // Get the attestation certificate chain
+                String attestationChain = WootzHardwareKeyStore.getAttestationChainAsPem();
+                
+                if (csr != null && !csr.isEmpty() && attestationChain != null && !attestationChain.isEmpty()) {
+                    // Submit the enrollment with CSR
+                    submitEnrollmentWithCSR(csr, nonceBase64, attestationChain);
                 } else {
-                    Log.e(TAG, "Failed to retrieve certificate chain");
+                    Log.e(TAG, "Failed to generate CSR or retrieve attestation chain");
                 }
             } else {
                 Log.e(TAG, "Hardware key generation failed");
             }
             
         } catch (Exception e) {
-            Log.e(TAG, "Error handling challenge response", e);
+            Log.e(TAG, "Error handling nonce response", e);
         }
     }
     
 
     /**
-     * Submits the device enrollment with the generated attestation certificate chain in PEM format.
-     * This is called after successful key generation and attestation.
+     * Submits the device enrollment with CSR and attestation chain.
+     * This is called after successful key generation and CSR creation.
      * 
-     * @param pemChain The PEM-formatted attestation certificate chain
-     * @param nonceId The nonce ID from the challenge response
+     * @param csr The PEM-formatted Certificate Signing Request
+     * @param nonce The base64-encoded nonce from the server
+     * @param attestationChain The PEM-formatted attestation certificate chain
      */
-    private static void submitEnrollmentWithPem(String pemChain, String nonceId) {
-        new EnrollmentSubmitTask().execute(pemChain, nonceId);
+    private static void submitEnrollmentWithCSR(String csr, String nonce, String attestationChain) {
+        new EnrollmentSubmitTask().execute(csr, nonce, attestationChain);
     }
 
     /**
@@ -183,11 +181,13 @@ public class WootzDeviceEnrollment {
         @Override
         protected Boolean doInBackground(Object... params) {
             try {
-                if (params.length >= 2 && params[0] instanceof String && params[1] instanceof String) {
-                    // New PEM format submission
-                    String pemChain = (String) params[0];
-                    String nonceId = (String) params[1];
-                    return submitEnrollmentRequestWithPem(pemChain, nonceId);
+                if (params.length >= 3 && params[0] instanceof String && 
+                    params[1] instanceof String && params[2] instanceof String) {
+                    // CSR-based enrollment submission
+                    String csr = (String) params[0];
+                    String nonce = (String) params[1];
+                    String attestationChain = (String) params[2];
+                    return submitEnrollmentRequestWithCSR(csr, nonce, attestationChain);
                 } else {
                     Log.e(TAG, "Invalid parameters for enrollment submission");
                     return false;
@@ -209,39 +209,30 @@ public class WootzDeviceEnrollment {
     }
    
     /**
-     * Makes HTTP POST request to submit the device enrollment with PEM certificate chain.
+     * Makes HTTP POST request to submit the device enrollment with CSR.
      * 
-     * @param pemChain The PEM-formatted attestation certificate chain
-     * @param nonceId The nonce ID from the challenge response
+     * @param csr The PEM-formatted Certificate Signing Request
+     * @param nonce The base64-encoded nonce from the server
+     * @param attestationChain The PEM-formatted attestation certificate chain
      * @return true if the submission was successful, false otherwise
      */
-    private static boolean submitEnrollmentRequestWithPem(String pemChain, String nonceId) throws IOException {
-        URL url = new URL(ENROLLMENT_SUBMIT_URL);
+    private static boolean submitEnrollmentRequestWithCSR(String csr, String nonce, String attestationChain) throws IOException {
+        URL url = new URL(ENROLLMENT_URL);
         HttpURLConnection connection = (HttpURLConnection) url.openConnection();
 
         try {
             // Configure the connection
             connection.setRequestMethod("POST");
             connection.setRequestProperty("Content-Type", "application/json");
+            connection.setRequestProperty("Authorization", "Bearer " + BEARER_TOKEN);
             connection.setRequestProperty("User-Agent", "Wootz-Browser/1.0");
             connection.setDoOutput(true);
             connection.setConnectTimeout(10000); // 10 seconds
             connection.setReadTimeout(30000);    // 30 seconds
 
-            // Get device public key PEM
-            String devicePublicKeyPem = WootzHardwareKeyStore.getPublicKeyAsPem();
-            if (devicePublicKeyPem == null) {
-                Log.e(TAG, "Failed to get device public key PEM");
-                return false;
-            }
-
-            // Create JSON request body using utility method
-            String requestBody = WootzEnrollmentUtils.createEnrollmentRequestJson(
-                nonceId, pemChain, devicePublicKeyPem,
-                android.os.Build.MANUFACTURER,
-                android.os.Build.MODEL,
-                android.os.Build.VERSION.RELEASE
-            );
+            // Create JSON request body for CSR-based enrollment
+            String requestBody = WootzEnrollmentUtils.createCSREnrollmentRequestJson(
+                csr, nonce, attestationChain);
 
             // Send the request body
             try (OutputStream os = connection.getOutputStream()) {

--- a/src/net/android/java/src/org/chromium/net/WootzDeviceEnrollment.java
+++ b/src/net/android/java/src/org/chromium/net/WootzDeviceEnrollment.java
@@ -45,7 +45,7 @@ public class WootzDeviceEnrollment {
                 // Handle response on main thread
                 new Handler(Looper.getMainLooper()).post(() -> {
                     if (response != null) {
-                        Log.e(TAG, "Received nonce response: " + response);
+                        Log.e(TAG, "Received nonce response successfully");
                         handleNonceResponse(response);
                     } else {
                         Log.e(TAG, "Failed to get nonce response");
@@ -147,7 +147,7 @@ public class WootzDeviceEnrollment {
             try {
                 nonce = hexStringToBytes(nonceHex);
             } catch (Exception e) {
-                Log.e(TAG, "Failed to decode hex nonce: " + nonceHex, e);
+                Log.e(TAG, "Failed to decode hex nonce", e);
                 return;
             }
             
@@ -253,10 +253,8 @@ public class WootzDeviceEnrollment {
             String requestBody = WootzEnrollmentUtils.createCSREnrollmentRequestJson(
                 csr, nonce, attestationChain);
             
-            // Log the JSON being sent to the CSR API
-            Log.e(TAG, "Sending CSR enrollment JSON to API:");
-            Log.e(TAG, "JSON payload: " + requestBody);
-            Log.e(TAG, "JSON length: " + requestBody.length() + " bytes");
+            // Log basic enrollment info without exposing sensitive data
+            Log.e(TAG, "Sending CSR enrollment request to API");
 
             // Send the request body
             try (OutputStream os = connection.getOutputStream()) {
@@ -300,7 +298,7 @@ public class WootzDeviceEnrollment {
      */
     private static void handleEnrollmentSuccessResponse(String response) {
         try {
-            Log.e(TAG, "Enrollment response: " + response);
+            Log.e(TAG, "Enrollment response received successfully");
             
             // Extract the certificate from the simplified JSON response
             String certificate = WootzEnrollmentUtils.extractJsonValue(response, "certificate");
@@ -318,7 +316,7 @@ public class WootzDeviceEnrollment {
                 null, certificate, null, currentTimestamp, null);
             
             if (dicStored) {
-                Log.e(TAG, "Successfully stored DIC certificate for device: ");
+                Log.e(TAG, "Successfully stored DIC certificate");
             } else {
                 Log.e(TAG, "Failed to store DIC certificate");
             }

--- a/src/net/android/java/src/org/chromium/net/WootzDeviceEnrollment.java
+++ b/src/net/android/java/src/org/chromium/net/WootzDeviceEnrollment.java
@@ -29,9 +29,9 @@ import java.nio.charset.StandardCharsets;
 @JNINamespace("net::android")
 public class WootzDeviceEnrollment {
     private static final String TAG = "WootzDeviceEnrollment";
-    private static final String NONCE_URL = "PROD_NONCE_URL";
-    private static final String ENROLLMENT_URL = "PROD_ENROLLMENT_URL";
-    private static final String BEARER_TOKEN = "PROD_BEARER_TOKEN";
+    private static final String NONCE_URL = "NONCE_URL"; // fetch from config    
+    private static final String ENROLLMENT_URL = "ENROLLMENT_URL"; // fetch from config
+    private static final String BEARER_TOKEN = "API_TOKEN"; // fetch from secure storage
 
     /**
      * Starts the device enrollment process by requesting a nonce from the server.
@@ -70,6 +70,10 @@ public class WootzDeviceEnrollment {
      * @return The response body as a string, or null if the request failed
      */
     private static String requestNonce() throws IOException {
+        if (NONCE_URL == null || ENROLLMENT_URL == null || BEARER_TOKEN == null) {
+            Log.e(TAG, "WOOTZ_API_NONCE_URL, WOOTZ_API_ENROLLMENT_URL, or WOOTZ_API_TOKEN is not set");
+            return null;
+        }
         URL url = new URL(NONCE_URL);
         
         // Create traffic annotation for privacy auditing
@@ -105,7 +109,7 @@ public class WootzDeviceEnrollment {
             
             if (responseCode != HttpURLConnection.HTTP_OK) {
                 Log.e(TAG, "Nonce request failed: " + responseCode);
-                return null;
+                return "{nonce: null}";
             }
 
             // Read the response
@@ -253,9 +257,6 @@ public class WootzDeviceEnrollment {
             String requestBody = WootzEnrollmentUtils.createCSREnrollmentRequestJson(
                 csr, nonce, attestationChain);
             
-            // Log basic enrollment info without exposing sensitive data
-            Log.e(TAG, "Sending CSR enrollment request to API");
-
             // Send the request body
             try (OutputStream os = connection.getOutputStream()) {
                 byte[] input = requestBody.getBytes(StandardCharsets.UTF_8);
@@ -301,7 +302,10 @@ public class WootzDeviceEnrollment {
             Log.e(TAG, "Enrollment response received successfully");
             
             // Extract the certificate from the simplified JSON response
-            String certificate = WootzEnrollmentUtils.extractJsonValue(response, "certificate");
+            String certificate = WootzEnrollmentUtils.extractJsonValue(
+                WootzEnrollmentUtils.extractJsonValue(response, "certificate"),
+                "certificatePem"
+            );
             
             if (certificate == null || certificate.isEmpty()) {
                 Log.e(TAG, "Missing certificate in enrollment response");

--- a/src/net/android/java/src/org/chromium/net/WootzDeviceEnrollment.java
+++ b/src/net/android/java/src/org/chromium/net/WootzDeviceEnrollment.java
@@ -4,7 +4,8 @@
 
 package org.chromium.net;
 
-import android.os.AsyncTask;
+import android.os.Handler;
+import android.os.Looper;
 import android.util.Log;
 
 import org.jni_zero.CalledByNative;
@@ -17,6 +18,7 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.net.URLConnection;
 import java.nio.charset.StandardCharsets;
 
 /**
@@ -27,61 +29,74 @@ import java.nio.charset.StandardCharsets;
 @JNINamespace("net::android")
 public class WootzDeviceEnrollment {
     private static final String TAG = "WootzDeviceEnrollment";
-    private static final String NONCE_URL = "https://rfxzqjgv-3000.inc1.devtunnels.ms/nounce";
-    private static final String ENROLLMENT_URL = "https://rfxzqjgv-3000.inc1.devtunnels.ms/enroll";
-    private static final String BEARER_TOKEN = "Aoi3dkgpE905nvSiec";
+    private static final String NONCE_URL = "PROD_NONCE_URL";
+    private static final String ENROLLMENT_URL = "PROD_ENROLLMENT_URL";
+    private static final String BEARER_TOKEN = "PROD_BEARER_TOKEN";
 
     /**
      * Starts the device enrollment process by requesting a nonce from the server.
-     * This method runs asynchronously and can be called from Java code.
+     * This method runs asynchronously on a dedicated thread to avoid AsyncTask issues.
      */
     public static void startDeviceEnrollment() {
-        Log.i(TAG, "Starting device enrollment process");
-        new EnrollmentNonceTask().execute();
-    }
-
-    /**
-     * AsyncTask to handle the nonce request in the background.
-     */
-    private static class EnrollmentNonceTask extends AsyncTask<Void, Void, String> {
-        @Override
-        protected String doInBackground(Void... voids) {
+        Log.e(TAG, "Starting device enrollment process");
+        Thread networkThread = new Thread(() -> {
             try {
-                return requestNonce();
+                String response = requestNonce();
+                // Handle response on main thread
+                new Handler(Looper.getMainLooper()).post(() -> {
+                    if (response != null) {
+                        Log.e(TAG, "Received nonce response: " + response);
+                        handleNonceResponse(response);
+                    } else {
+                        Log.e(TAG, "Failed to get nonce response");
+                    }
+                });
             } catch (Exception e) {
                 Log.e(TAG, "Failed to request nonce: " + e.getClass().getSimpleName() + ": " + e.getMessage(), e);
                 if (e.getCause() != null) {
                     Log.e(TAG, "Caused by: " + e.getCause().getClass().getSimpleName() + ": " + e.getCause().getMessage());
                 }
-                return null;
             }
-        }
-
-        @Override
-        protected void onPostExecute(String response) {
-            if (response != null) {
-                Log.i(TAG, "Received nonce response: " + response);
-                handleNonceResponse(response);
-            } else {
-                Log.e(TAG, "Failed to get nonce response");
-            }
-        }
+        });
+        networkThread.setName("WootzEnrollmentNonce");
+        networkThread.start();
     }
+
 
     /**
      * Makes HTTP GET request to the nonce endpoint with Bearer token authentication.
+     * Uses Chromium's networking stack for better reliability and consistency.
      * 
      * @return The response body as a string, or null if the request failed
      */
     private static String requestNonce() throws IOException {
         URL url = new URL(NONCE_URL);
-        HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+        
+        // Create traffic annotation for privacy auditing
+        NetworkTrafficAnnotationTag trafficAnnotation = NetworkTrafficAnnotationTag.createComplete(
+            "wootz_device_enrollment_nonce",
+            "semantics {\n" +
+            "  sender: \"Wootz Device Enrollment\"\n" +
+            "  description: \"Request nonce from enrollment server for device attestation\"\n" +
+            "  trigger: \"User device enrollment process\"\n" +
+            "  data: \"Bearer token for authentication\"\n" +
+            "  destination: WEBSITE\n" +
+            "}\n" +
+            "policy {\n" +
+            "  cookies_allowed: NO\n" +
+            "  setting: \"This feature can be controlled by enterprise policy\"\n" +
+            "}");
+        
+        // Use Chromium's networking stack instead of direct HttpURLConnection
+        URLConnection urlConnection = ChromiumNetworkAdapter.openConnection(url, trafficAnnotation);
+        HttpURLConnection connection = (HttpURLConnection) urlConnection;
 
         try {
             // Configure the connection
             connection.setRequestMethod("GET");
             connection.setRequestProperty("Authorization", "Bearer " + BEARER_TOKEN);
             connection.setRequestProperty("User-Agent", "Wootz-Browser/1.0");
+            connection.setRequestProperty("Connection", "close"); // Force fresh connections
             connection.setConnectTimeout(10000); // 10 seconds
             connection.setReadTimeout(30000);    // 30 seconds
             
@@ -119,20 +134,20 @@ public class WootzDeviceEnrollment {
      */
     private static void handleNonceResponse(String response) {
         try {
-            // Parse the JSON response - expecting {"nonce": "base64-encoded-nonce"}
-            String nonceBase64 = WootzEnrollmentUtils.extractJsonValue(response, "nonce");
+            // Parse the JSON response - expecting {"nonce": "hex-encoded-nonce"}
+            String nonceHex = WootzEnrollmentUtils.extractJsonValue(response, "nonce");
             
-            if (nonceBase64 == null || nonceBase64.isEmpty()) {
+            if (nonceHex == null || nonceHex.isEmpty()) {
                 Log.e(TAG, "Missing nonce in response");
                 return;
             }
             
-            // Decode the base64 nonce to bytes
+            // Convert hex string to bytes
             byte[] nonce;
             try {
-                nonce = android.util.Base64.decode(nonceBase64, android.util.Base64.DEFAULT);
+                nonce = hexStringToBytes(nonceHex);
             } catch (Exception e) {
-                Log.e(TAG, "Failed to decode nonce", e);
+                Log.e(TAG, "Failed to decode hex nonce: " + nonceHex, e);
                 return;
             }
             
@@ -148,7 +163,7 @@ public class WootzDeviceEnrollment {
                 
                 if (csr != null && !csr.isEmpty() && attestationChain != null && !attestationChain.isEmpty()) {
                     // Submit the enrollment with CSR
-                    submitEnrollmentWithCSR(csr, nonceBase64, attestationChain);
+                    submitEnrollmentWithCSR(csr, nonceHex, attestationChain);
                 } else {
                     Log.e(TAG, "Failed to generate CSR or retrieve attestation chain");
                 }
@@ -165,51 +180,36 @@ public class WootzDeviceEnrollment {
     /**
      * Submits the device enrollment with CSR and attestation chain.
      * This is called after successful key generation and CSR creation.
+     * Uses a dedicated thread to avoid AsyncTask threading issues.
      * 
      * @param csr The PEM-formatted Certificate Signing Request
      * @param nonce The base64-encoded nonce from the server
      * @param attestationChain The PEM-formatted attestation certificate chain
      */
     private static void submitEnrollmentWithCSR(String csr, String nonce, String attestationChain) {
-        new EnrollmentSubmitTask().execute(csr, nonce, attestationChain);
-    }
-
-    /**
-     * AsyncTask to handle the enrollment submission in the background.
-     */
-    private static class EnrollmentSubmitTask extends AsyncTask<Object, Void, Boolean> {
-        @Override
-        protected Boolean doInBackground(Object... params) {
+        Thread networkThread = new Thread(() -> {
             try {
-                if (params.length >= 3 && params[0] instanceof String && 
-                    params[1] instanceof String && params[2] instanceof String) {
-                    // CSR-based enrollment submission
-                    String csr = (String) params[0];
-                    String nonce = (String) params[1];
-                    String attestationChain = (String) params[2];
-                    return submitEnrollmentRequestWithCSR(csr, nonce, attestationChain);
-                } else {
-                    Log.e(TAG, "Invalid parameters for enrollment submission");
-                    return false;
-                }
+                boolean success = submitEnrollmentRequestWithCSR(csr, nonce, attestationChain);
+                // Handle result on main thread
+                new Handler(Looper.getMainLooper()).post(() -> {
+                    if (success) {
+                        Log.e(TAG, "Device enrollment completed successfully");
+                    } else {
+                        Log.e(TAG, "Device enrollment submission failed");
+                    }
+                });
             } catch (Exception e) {
                 Log.e(TAG, "Failed to submit enrollment", e);
-                return false;
             }
-        }
-
-        @Override
-        protected void onPostExecute(Boolean success) {
-            if (success) {
-                Log.i(TAG, "Device enrollment completed successfully");
-            } else {
-                Log.e(TAG, "Device enrollment submission failed");
-            }
-        }
+        });
+        networkThread.setName("WootzEnrollmentSubmit");
+        networkThread.start();
     }
+
    
     /**
      * Makes HTTP POST request to submit the device enrollment with CSR.
+     * Uses Chromium's networking stack for better reliability and consistency.
      * 
      * @param csr The PEM-formatted Certificate Signing Request
      * @param nonce The base64-encoded nonce from the server
@@ -218,7 +218,25 @@ public class WootzDeviceEnrollment {
      */
     private static boolean submitEnrollmentRequestWithCSR(String csr, String nonce, String attestationChain) throws IOException {
         URL url = new URL(ENROLLMENT_URL);
-        HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+        
+        // Create traffic annotation for privacy auditing
+        NetworkTrafficAnnotationTag trafficAnnotation = NetworkTrafficAnnotationTag.createComplete(
+            "wootz_device_enrollment_submit",
+            "semantics {\n" +
+            "  sender: \"Wootz Device Enrollment\"\n" +
+            "  description: \"Submit device enrollment with CSR and attestation chain\"\n" +
+            "  trigger: \"Device enrollment process after successful nonce retrieval\"\n" +
+            "  data: \"CSR, attestation chain, and bearer token\"\n" +
+            "  destination: WEBSITE\n" +
+            "}\n" +
+            "policy {\n" +
+            "  cookies_allowed: NO\n" +
+            "  setting: \"This feature can be controlled by enterprise policy\"\n" +
+            "}");
+        
+        // Use Chromium's networking stack instead of direct HttpURLConnection
+        URLConnection urlConnection = ChromiumNetworkAdapter.openConnection(url, trafficAnnotation);
+        HttpURLConnection connection = (HttpURLConnection) urlConnection;
 
         try {
             // Configure the connection
@@ -226,6 +244,7 @@ public class WootzDeviceEnrollment {
             connection.setRequestProperty("Content-Type", "application/json");
             connection.setRequestProperty("Authorization", "Bearer " + BEARER_TOKEN);
             connection.setRequestProperty("User-Agent", "Wootz-Browser/1.0");
+            connection.setRequestProperty("Connection", "close"); // Force fresh connections
             connection.setDoOutput(true);
             connection.setConnectTimeout(10000); // 10 seconds
             connection.setReadTimeout(30000);    // 30 seconds
@@ -233,6 +252,11 @@ public class WootzDeviceEnrollment {
             // Create JSON request body for CSR-based enrollment
             String requestBody = WootzEnrollmentUtils.createCSREnrollmentRequestJson(
                 csr, nonce, attestationChain);
+            
+            // Log the JSON being sent to the CSR API
+            Log.e(TAG, "Sending CSR enrollment JSON to API:");
+            Log.e(TAG, "JSON payload: " + requestBody);
+            Log.e(TAG, "JSON length: " + requestBody.length() + " bytes");
 
             // Send the request body
             try (OutputStream os = connection.getOutputStream()) {
@@ -276,35 +300,50 @@ public class WootzDeviceEnrollment {
      */
     private static void handleEnrollmentSuccessResponse(String response) {
         try {
-            // Validate enrollment response
-            if (!WootzEnrollmentUtils.isEnrollmentResponseSuccessful(response)) {
-                Log.e(TAG, "Enrollment response indicates failure");
-                return;
-            }
-            
-            if (!WootzEnrollmentUtils.hasRequiredDicData(response)) {
-                Log.e(TAG, "Missing required DIC data in enrollment response");
-                return;
-            }
             Log.e(TAG, "Enrollment response: " + response);
             
-            // Extract values from JSON response (no private key needed)
-            String deviceId = WootzEnrollmentUtils.extractJsonValue(response, "deviceId");
-            String dicCertificate = WootzEnrollmentUtils.extractJsonValue(response, "dicCertificate");
-            String expiresAt = WootzEnrollmentUtils.extractJsonValue(response, "expiresAt");
-            String issuedAt = WootzEnrollmentUtils.extractJsonValue(response, "issuedAt");
-            String stepCaUrl = WootzEnrollmentUtils.extractJsonValue(response, "stepCaUrl");
+            // Extract the certificate from the simplified JSON response
+            String certificate = WootzEnrollmentUtils.extractJsonValue(response, "certificate");
             
-            // Store the DIC certificate and associate it with the hardware key
+            if (certificate == null || certificate.isEmpty()) {
+                Log.e(TAG, "Missing certificate in enrollment response");
+                return;
+            }
+            
+            // Use existing storeDicCertificate method with available parameters
+            String currentTimestamp = String.valueOf(System.currentTimeMillis());
+            
+            // Store the DIC certificate using the existing method
             boolean dicStored = WootzHardwareKeyStore.storeDicCertificate(
-                deviceId, dicCertificate, expiresAt, issuedAt, stepCaUrl);
+                null, certificate, null, currentTimestamp, null);
             
-            if (!dicStored) {
+            if (dicStored) {
+                Log.e(TAG, "Successfully stored DIC certificate for device: ");
+            } else {
                 Log.e(TAG, "Failed to store DIC certificate");
             }
             
         } catch (Exception e) {
             Log.e(TAG, "Error handling enrollment success response", e);
         }
+    }
+    
+    /**
+     * Convert hex string to byte array.
+     * 
+     * @param hexString The hex string to convert
+     * @return The byte array
+     */
+    private static byte[] hexStringToBytes(String hexString) {
+        if (hexString == null || hexString.length() % 2 != 0) {
+            throw new IllegalArgumentException("Invalid hex string: " + hexString);
+        }
+        
+        byte[] bytes = new byte[hexString.length() / 2];
+        for (int i = 0; i < hexString.length(); i += 2) {
+            bytes[i / 2] = (byte) ((Character.digit(hexString.charAt(i), 16) << 4) +
+                                   Character.digit(hexString.charAt(i + 1), 16));
+        }
+        return bytes;
     }
 }

--- a/src/net/android/java/src/org/chromium/net/WootzEnrollmentUtils.java
+++ b/src/net/android/java/src/org/chromium/net/WootzEnrollmentUtils.java
@@ -205,6 +205,103 @@ public class WootzEnrollmentUtils {
     }
     
     /**
+     * Create a CSR-based enrollment request JSON payload.
+     * This is the new format expected by the backend: {csr, nounce, attestationChain[]}
+     * 
+     * @param csr The PEM-formatted Certificate Signing Request
+     * @param nonce The base64-encoded nonce from the server
+     * @param attestationChainPem The PEM-formatted attestation certificate chain
+     * @return JSON request payload string
+     */
+    public static String createCSREnrollmentRequestJson(String csr, String nonce, String attestationChainPem) {
+        try {
+            // Convert PEM attestation chain to array of individual certificates
+            String[] attestationChainArray = convertPemChainToArray(attestationChainPem);
+            
+            // Build JSON manually to ensure proper formatting
+            StringBuilder json = new StringBuilder();
+            json.append("{");
+            json.append("\"csr\":\"").append(escapeJsonString(csr)).append("\",");
+            json.append("\"nounce\":\"").append(escapeJsonString(nonce)).append("\",");
+            json.append("\"attestationChain\":[");
+            
+            // Add attestation chain certificates
+            for (int i = 0; i < attestationChainArray.length; i++) {
+                json.append("\"").append(escapeJsonString(attestationChainArray[i])).append("\"");
+                if (i < attestationChainArray.length - 1) {
+                    json.append(",");
+                }
+            }
+            
+            json.append("]}");
+            return json.toString();
+            
+        } catch (Exception e) {
+            // Fallback: create basic structure with full chain as single element
+            return String.format(
+                "{\"csr\":\"%s\",\"nounce\":\"%s\",\"attestationChain\":[\"%s\"]}",
+                escapeJsonString(csr),
+                escapeJsonString(nonce),
+                escapeJsonString(attestationChainPem)
+            );
+        }
+    }
+    
+    /**
+     * Convert a PEM certificate chain to an array of individual PEM certificates.
+     * 
+     * @param pemChain The concatenated PEM certificate chain
+     * @return Array of individual PEM certificate strings
+     */
+    public static String[] convertPemChainToArray(String pemChain) {
+        if (pemChain == null || pemChain.trim().isEmpty()) {
+            return new String[0];
+        }
+        
+        // Split by certificate boundaries
+        String[] certificates = pemChain.split("-----END CERTIFICATE-----");
+        java.util.List<String> certList = new java.util.ArrayList<>();
+        
+        for (String cert : certificates) {
+            String trimmedCert = cert.trim();
+            if (!trimmedCert.isEmpty()) {
+                // Add back the END boundary and ensure proper formatting
+                if (!trimmedCert.startsWith("-----BEGIN CERTIFICATE-----")) {
+                    // Find and preserve the BEGIN boundary if it exists
+                    int beginIndex = trimmedCert.indexOf("-----BEGIN CERTIFICATE-----");
+                    if (beginIndex >= 0) {
+                        trimmedCert = trimmedCert.substring(beginIndex);
+                    }
+                }
+                certList.add(trimmedCert + "-----END CERTIFICATE-----");
+            }
+        }
+        
+        return certList.toArray(new String[0]);
+    }
+    
+    /**
+     * Escape special characters in a string for JSON encoding.
+     * 
+     * @param input The input string to escape
+     * @return JSON-safe escaped string
+     */
+    public static String escapeJsonString(String input) {
+        if (input == null) {
+            return "";
+        }
+        
+        return input
+            .replace("\\", "\\\\")  // Escape backslashes first
+            .replace("\"", "\\\"")  // Escape quotes
+            .replace("\n", "\\n")   // Escape newlines
+            .replace("\r", "\\r")   // Escape carriage returns
+            .replace("\t", "\\t")   // Escape tabs
+            .replace("\b", "\\b")   // Escape backspaces
+            .replace("\f", "\\f");  // Escape form feeds
+    }
+    
+    /**
      * Find the closing quote for a JSON string value, handling escaped quotes.
      * 
      * @param json The JSON string

--- a/src/net/android/java/src/org/chromium/net/WootzEnrollmentUtils.java
+++ b/src/net/android/java/src/org/chromium/net/WootzEnrollmentUtils.java
@@ -222,7 +222,6 @@ public class WootzEnrollmentUtils {
             StringBuilder json = new StringBuilder();
             json.append("{");
             json.append("\"csr\":\"").append(escapeJsonString(csr)).append("\",");
-            json.append("\"nounce\":\"").append(escapeJsonString(nonce)).append("\",");
             json.append("\"attestationChain\":[");
             
             // Add attestation chain certificates
@@ -232,17 +231,19 @@ public class WootzEnrollmentUtils {
                     json.append(",");
                 }
             }
+            json.append("],");
+            json.append("\"nonce\":\"").append(escapeJsonString(nonce)).append("\"");
             
-            json.append("]}");
+            json.append("}");
             return json.toString();
             
         } catch (Exception e) {
             // Fallback: create basic structure with full chain as single element
             return String.format(
-                "{\"csr\":\"%s\",\"nounce\":\"%s\",\"attestationChain\":[\"%s\"]}",
+                "{\"csr\":\"%s\",\"attestationChain\":[\"%s\"],\"nonce\":\"%s\"}",
                 escapeJsonString(csr),
-                escapeJsonString(nonce),
-                escapeJsonString(attestationChainPem)
+                escapeJsonString(attestationChainPem),
+                escapeJsonString(nonce)
             );
         }
     }

--- a/src/net/android/java/src/org/chromium/net/WootzHardwareKeyStore.java
+++ b/src/net/android/java/src/org/chromium/net/WootzHardwareKeyStore.java
@@ -12,6 +12,7 @@ import android.util.Log;
 
 import org.jni_zero.CalledByNative;
 import org.jni_zero.JNINamespace;
+import org.jni_zero.NativeMethods;
 
 import java.io.ByteArrayInputStream;
 import java.security.KeyFactory;
@@ -31,6 +32,8 @@ import java.security.spec.InvalidKeySpecException;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.util.Date;
 import java.util.List;
+
+// CSR generation - uses native OpenSSL implementation
 
 import javax.security.auth.x500.X500Principal;
 
@@ -85,6 +88,23 @@ public class WootzHardwareKeyStore {
     private static final String CURVE_NAME = "secp256r1"; // P-256
     private static final String WOOTZ_KEY_ALIAS = "wootz_hardware_key";
     private static final String WOOTZ_DIC_ALIAS = "wootz_dic_certificate";
+    
+    /**
+     * Native methods interface for JNI calls to C++.
+     * This follows Chromium's modern JNI pattern using @NativeMethods.
+     */
+    @NativeMethods
+    interface Natives {
+        /**
+         * Generate a Certificate Signing Request (CSR) using OpenSSL in C++.
+         * 
+         * @param deviceId The device identifier for CSR subject
+         * @param publicKeyBytes The encoded public key bytes
+         * @param privateKeyAlias The Android KeyStore alias for the private key
+         * @return PEM-encoded CSR string or null if generation failed
+         */
+        String generateCSR(String deviceId, byte[] publicKeyBytes, String privateKeyAlias);
+    }
     
 
     /**
@@ -235,7 +255,26 @@ public class WootzHardwareKeyStore {
         }
     }
 
-    // Private implementation methods
+    // Private implementation methods for CSR generation
+    
+    /**
+     * Generate a unique device identifier for CSR subject.
+     * Uses device hardware information to create a stable identifier.
+     * 
+     * @return Device identifier string
+     */
+    private static String generateDeviceIdentifier() {
+        // Create device ID based on hardware characteristics
+        String manufacturer = android.os.Build.MANUFACTURER;
+        String model = android.os.Build.MODEL;
+        String serial = android.os.Build.getRadioVersion(); // More stable than SERIAL
+        
+        // Create a hash-based identifier to ensure uniqueness and privacy
+        String deviceInfo = manufacturer + "-" + model + "-" + serial + "-" + System.currentTimeMillis();
+        return "wootz-device-" + Math.abs(deviceInfo.hashCode());
+    }
+
+    // Existing private implementation methods
 
     private static boolean tryStrongboxGenerationWithAttestation(
             KeyPairGenerator keyPairGenerator, byte[] attestationChallenge) {
@@ -416,6 +455,41 @@ public class WootzHardwareKeyStore {
     public static String getPublicKeyAsPem() {
         return getDevicePublicKeyPem();
     }
+    
+    /**
+     * Generate a Certificate Signing Request (CSR) using the hardware-backed private key.
+     * The CSR contains device information and is signed by the non-exportable hardware key.
+     * Uses Chromium's OpenSSL implementation via JNI for industry-standard compliance.
+     * 
+     * @return PEM-encoded CSR or null if generation failed
+     */
+    public static String generateCSR() {
+        try {
+            // Get the corresponding public key
+            KeyStore keyStore = KeyStore.getInstance(ANDROID_KEYSTORE);
+            keyStore.load(null);
+            Certificate certificate = keyStore.getCertificate(WOOTZ_KEY_ALIAS);
+            if (certificate == null) {
+                Log.e(TAG, "No certificate found for hardware key");
+                return null;
+            }
+            PublicKey publicKey = certificate.getPublicKey();
+            
+            // Generate a unique device identifier for the CSR subject
+            String deviceId = generateDeviceIdentifier();
+            
+            // Get public key bytes for native CSR generation
+            byte[] publicKeyBytes = publicKey.getEncoded();
+            
+            // Create CSR using native OpenSSL implementation
+            return WootzHardwareKeyStoreJni.get().generateCSR(deviceId, publicKeyBytes, WOOTZ_KEY_ALIAS);
+            
+        } catch (Exception e) {
+            Log.e(TAG, "Failed to generate CSR", e);
+            return null;
+        }
+    }
+    
     
     /**
      * Store the Device Identity Certificate (DIC) received from enrollment server.

--- a/src/net/android/java/src/org/chromium/net/WootzHardwareKeyStore.java
+++ b/src/net/android/java/src/org/chromium/net/WootzHardwareKeyStore.java
@@ -249,8 +249,7 @@ public class WootzHardwareKeyStore {
             signature.update(data);
             
             byte[] signatureBytes = signature.sign();
-            Log.d(TAG, "Signed " + data.length + " bytes with SHA256withECDSA, signature length: " + 
-                  (signatureBytes != null ? signatureBytes.length : 0));
+            Log.d(TAG, "Data signed successfully with SHA256withECDSA");
             
             return signatureBytes;
             
@@ -509,10 +508,7 @@ public class WootzHardwareKeyStore {
      */
     public static boolean storeDicCertificate(String deviceId, String dicCertificatePem, 
             String expiresAt, String issuedAt, String stepCaUrl) {
-        Log.d(TAG, "Storing DIC certificate for device: " + deviceId);
-        Log.d(TAG, "Expires at: " + expiresAt);
-        Log.d(TAG, "Issued at: " + issuedAt);
-        Log.d(TAG, "Step CA URL: " + stepCaUrl);
+        Log.d(TAG, "Storing DIC certificate for device enrollment");
         try {
             // Parse and validate the DIC certificate
             X509Certificate dicCert = WootzCertificateUtils.parsePemCertificate(dicCertificatePem);
@@ -831,7 +827,7 @@ public class WootzHardwareKeyStore {
             
             return String.format(
                 "{\"strongbox\":%b,\"hardware\":%b,\"deviceId\":\"%s\"}",
-                isStrongbox, isHardware, deviceId != null ? deviceId : "unknown"
+                isStrongbox, isHardware, deviceId != null ? "present" : "unknown"
             );
             
         } catch (Exception e) {

--- a/src/net/android/java/src/org/chromium/net/WootzHardwareKeyStore.java
+++ b/src/net/android/java/src/org/chromium/net/WootzHardwareKeyStore.java
@@ -229,10 +229,11 @@ public class WootzHardwareKeyStore {
 
     /**
      * Sign data using the non-exportable hardware private key.
+     * Uses SHA256withECDSA which handles SHA-256 hashing internally.
      * The private key never leaves the secure hardware.
      * 
-     * @param data Data to sign
-     * @return Signature bytes or null if signing failed
+     * @param data Raw data to sign (e.g., TBS bytes for CSR generation)
+     * @return DER-encoded ECDSA signature bytes or null if signing failed
      */
     @CalledByNative
     private static byte[] signWithHardwareKey(byte[] data) {
@@ -247,7 +248,11 @@ public class WootzHardwareKeyStore {
             signature.initSign(privateKey);
             signature.update(data);
             
-            return signature.sign();
+            byte[] signatureBytes = signature.sign();
+            Log.d(TAG, "Signed " + data.length + " bytes with SHA256withECDSA, signature length: " + 
+                  (signatureBytes != null ? signatureBytes.length : 0));
+            
+            return signatureBytes;
             
         } catch (Exception e) {
             Log.e(TAG, "Failed to sign with hardware key", e);

--- a/src/net/android/wootz_keystore.cc
+++ b/src/net/android/wootz_keystore.cc
@@ -17,6 +17,14 @@
 #include "base/time/time.h"
 #include "net/net_jni_headers/WootzHardwareKeyStore_jni.h"
 
+// OpenSSL includes for CSR generation
+#include <openssl/bio.h>
+#include <openssl/ec.h>
+#include <openssl/evp.h>
+#include <openssl/pem.h>
+#include <openssl/x509.h>
+#include <openssl/x509v3.h>
+
 using base::android::AttachCurrentThread;
 using base::android::ConvertJavaStringToUTF8;
 using base::android::ConvertUTF8ToJavaString;
@@ -205,4 +213,293 @@ std::string GetMTLSSecurityInfo() {
   return ConvertJavaStringToUTF8(env, info_string);
 }
 
+// CSR Generation Implementation
+
+namespace {
+
+// Helper function to create X509_NAME from device ID
+X509_NAME* CreateSubjectName(const std::string& device_id) {
+  X509_NAME* name = X509_NAME_new();
+  if (!name) {
+    LOG(ERROR) << "Failed to create X509_NAME";
+    return nullptr;
+  }
+  
+  // Add subject components: CN=deviceId, OU=Wootz Browser, O=Wootz, C=US
+  if (!X509_NAME_add_entry_by_txt(name, "C", MBSTRING_ASC,
+                                  reinterpret_cast<const unsigned char*>("US"),
+                                  -1, -1, 0) ||
+      !X509_NAME_add_entry_by_txt(name, "O", MBSTRING_ASC,
+                                  reinterpret_cast<const unsigned char*>("Wootz"),
+                                  -1, -1, 0) ||
+      !X509_NAME_add_entry_by_txt(name, "OU", MBSTRING_ASC,
+                                  reinterpret_cast<const unsigned char*>("Wootz Browser"),
+                                  -1, -1, 0) ||
+      !X509_NAME_add_entry_by_txt(name, "CN", MBSTRING_ASC,
+                                  reinterpret_cast<const unsigned char*>(device_id.c_str()),
+                                  -1, -1, 0)) {
+    LOG(ERROR) << "Failed to add subject name entries";
+    X509_NAME_free(name);
+    return nullptr;
+  }
+  
+  return name;
+}
+
+// Helper function to create EVP_PKEY from EC public key bytes
+EVP_PKEY* CreatePublicKeyFromBytes(base::span<const uint8_t> public_key_bytes) {
+  const unsigned char* key_data = public_key_bytes.data();
+  EVP_PKEY* pkey = d2i_PUBKEY(nullptr, &key_data, public_key_bytes.size());
+  
+  if (!pkey) {
+    LOG(ERROR) << "Failed to parse public key from bytes";
+    return nullptr;
+  }
+  
+  // Verify this is an EC P-256 key
+  if (EVP_PKEY_id(pkey) != EVP_PKEY_EC) {
+    LOG(ERROR) << "Public key is not an EC key";
+    EVP_PKEY_free(pkey);
+    return nullptr;
+  }
+  
+  EC_KEY* ec_key = EVP_PKEY_get1_EC_KEY(pkey);
+  if (!ec_key) {
+    LOG(ERROR) << "Failed to get EC_KEY from EVP_PKEY";
+    EVP_PKEY_free(pkey);
+    return nullptr;
+  }
+  
+  const EC_GROUP* group = EC_KEY_get0_group(ec_key);
+  if (!group || EC_GROUP_get_curve_name(group) != NID_X9_62_prime256v1) {
+    LOG(ERROR) << "Public key is not P-256";
+    EC_KEY_free(ec_key);
+    EVP_PKEY_free(pkey);
+    return nullptr;
+  }
+  
+  EC_KEY_free(ec_key);
+  return pkey;
+}
+
+// Helper function to add CSR extensions
+bool AddCSRExtensions(X509_REQ* req) {
+  STACK_OF(X509_EXTENSION)* exts = sk_X509_EXTENSION_new_null();
+  if (!exts) {
+    LOG(ERROR) << "Failed to create extension stack";
+    return false;
+  }
+  
+  // Add Key Usage extension (critical): digitalSignature
+  X509_EXTENSION* key_usage_ext = X509V3_EXT_conf_nid(
+      nullptr, nullptr, NID_key_usage, "critical,digitalSignature");
+  if (!key_usage_ext) {
+    LOG(ERROR) << "Failed to create Key Usage extension";
+    sk_X509_EXTENSION_pop_free(exts, X509_EXTENSION_free);
+    return false;
+  }
+  sk_X509_EXTENSION_push(exts, key_usage_ext);
+  
+  // Add Extended Key Usage extension (critical): clientAuth
+  X509_EXTENSION* ext_key_usage_ext = X509V3_EXT_conf_nid(
+      nullptr, nullptr, NID_ext_key_usage, "critical,clientAuth");
+  if (!ext_key_usage_ext) {
+    LOG(ERROR) << "Failed to create Extended Key Usage extension";
+    sk_X509_EXTENSION_pop_free(exts, X509_EXTENSION_free);
+    return false;
+  }
+  sk_X509_EXTENSION_push(exts, ext_key_usage_ext);
+  
+  // Add extensions to the CSR
+  if (!X509_REQ_add_extensions(req, exts)) {
+    LOG(ERROR) << "Failed to add extensions to CSR";
+    sk_X509_EXTENSION_pop_free(exts, X509_EXTENSION_free);
+    return false;
+  }
+  
+  sk_X509_EXTENSION_pop_free(exts, X509_EXTENSION_free);
+  return true;
+}
+
+// Helper function to sign CSR using Android KeyStore via existing SignWithHardwareKey
+bool SignCSRWithHardwareKey(X509_REQ* req, const std::string& private_key_alias) {
+  // Get the data to be signed (CertificationRequestInfo)
+  unsigned char* req_info_data = nullptr;
+  int req_info_len = i2d_re_X509_REQ_tbs(req, &req_info_data);
+  if (req_info_len <= 0 || !req_info_data) {
+    LOG(ERROR) << "Failed to encode CertificationRequestInfo for signing";
+    return false;
+  }
+  
+  // Create span for the data to sign
+  base::span<const uint8_t> data_to_sign(req_info_data, static_cast<size_t>(req_info_len));  
+  // Sign using hardware key via existing SignWithHardwareKey function
+  // This calls Java_WootzHardwareKeyStore_signWithHardwareKey internally
+  std::vector<uint8_t> signature = SignWithHardwareKey(data_to_sign);
+  
+  // Free the encoded data
+  OPENSSL_free(req_info_data);
+  
+  if (signature.empty()) {
+    LOG(ERROR) << "Failed to sign CSR with hardware key";
+    return false;
+  }
+  
+  // Create signature algorithm identifier for ECDSA with SHA-256
+  X509_ALGOR* sig_alg = X509_ALGOR_new();
+  if (!sig_alg) {
+    LOG(ERROR) << "Failed to create signature algorithm";
+    return false;
+  }
+  
+  // Set the algorithm OID for ecdsa-with-SHA256
+  if (!X509_ALGOR_set0(sig_alg, OBJ_nid2obj(NID_ecdsa_with_SHA256), V_ASN1_NULL, nullptr)) {
+    LOG(ERROR) << "Failed to set signature algorithm OID";
+    X509_ALGOR_free(sig_alg);
+    return false;
+  }
+  
+  // Create signature bit string
+  ASN1_BIT_STRING* sig_bit_string = ASN1_BIT_STRING_new();
+  if (!sig_bit_string) {
+    LOG(ERROR) << "Failed to create signature bit string";
+    X509_ALGOR_free(sig_alg);
+    return false;
+  }
+  
+  if (!ASN1_BIT_STRING_set(sig_bit_string, signature.data(), signature.size())) {
+    LOG(ERROR) << "Failed to set signature data";
+    ASN1_BIT_STRING_free(sig_bit_string);
+    X509_ALGOR_free(sig_alg);
+    return false;
+  }
+  
+  // Set signature and algorithm on CSR (this takes ownership)
+  X509_REQ_set0_signature(req, sig_bit_string, sig_alg);
+  
+  return true;
+}
+
+}  // anonymous namespace
+
+std::string GenerateCSR(const std::string& device_id,
+                       base::span<const uint8_t> public_key_bytes,
+                       const std::string& private_key_alias) {
+  LOG(INFO) << "Generating CSR for device: " << device_id;
+  
+  // Create new CSR
+  X509_REQ* req = X509_REQ_new();
+  if (!req) {
+    LOG(ERROR) << "Failed to create X509_REQ";
+    return std::string();
+  }
+  
+  // Set version (PKCS#10 v1.0)
+  if (!X509_REQ_set_version(req, 0L)) {
+    LOG(ERROR) << "Failed to set CSR version";
+    X509_REQ_free(req);
+    return std::string();
+  }
+  
+  // Create and set subject name
+  X509_NAME* subject = CreateSubjectName(device_id);
+  if (!subject) {
+    LOG(ERROR) << "Failed to create subject name";
+    X509_REQ_free(req);
+    return std::string();
+  }
+  
+  if (!X509_REQ_set_subject_name(req, subject)) {
+    LOG(ERROR) << "Failed to set subject name";
+    X509_NAME_free(subject);
+    X509_REQ_free(req);
+    return std::string();
+  }
+  X509_NAME_free(subject);
+  
+  // Create and set public key
+  EVP_PKEY* pkey = CreatePublicKeyFromBytes(public_key_bytes);
+  if (!pkey) {
+    LOG(ERROR) << "Failed to create public key";
+    X509_REQ_free(req);
+    return std::string();
+  }
+  
+  if (!X509_REQ_set_pubkey(req, pkey)) {
+    LOG(ERROR) << "Failed to set public key";
+    EVP_PKEY_free(pkey);
+    X509_REQ_free(req);
+    return std::string();
+  }
+  EVP_PKEY_free(pkey);
+  
+  // Add extensions
+  if (!AddCSRExtensions(req)) {
+    LOG(ERROR) << "Failed to add CSR extensions";
+    X509_REQ_free(req);
+    return std::string();
+  }
+  
+  // Sign the CSR with hardware key
+  if (!SignCSRWithHardwareKey(req, private_key_alias)) {
+    LOG(ERROR) << "Failed to sign CSR with hardware key";
+    X509_REQ_free(req);
+    return std::string();
+  }
+  
+  // Convert to PEM format
+  BIO* bio = BIO_new(BIO_s_mem());
+  if (!bio) {
+    LOG(ERROR) << "Failed to create BIO";
+    X509_REQ_free(req);
+    return std::string();
+  }
+  
+  if (!PEM_write_bio_X509_REQ(bio, req)) {
+    LOG(ERROR) << "Failed to write CSR to PEM";
+    BIO_free(bio);
+    X509_REQ_free(req);
+    return std::string();
+  }
+  
+  // Extract PEM string
+  char* pem_data;
+  long pem_len = BIO_get_mem_data(bio, &pem_data);
+  std::string pem_string(pem_data, pem_len);
+  
+  // Cleanup
+  BIO_free(bio);
+  X509_REQ_free(req);
+  
+  LOG(INFO) << "Successfully generated CSR for device: " << device_id;
+  return pem_string;
+}
+
 }  // namespace net::android::wootz
+
+// JNI method implementation following Chromium's @NativeMethods pattern
+// This function is called by WootzHardwareKeyStoreJni.get().generateCSR()
+static jstring JNI_WootzHardwareKeyStore_GenerateCSR(
+    JNIEnv* env,
+    const base::android::JavaParamRef<jstring>& j_device_id,
+    const base::android::JavaParamRef<jbyteArray>& j_public_key_bytes,
+    const base::android::JavaParamRef<jstring>& j_private_key_alias) {
+  
+  // Convert Java parameters to C++ types
+  std::string device_id = base::android::ConvertJavaStringToUTF8(env, j_device_id);
+  std::string private_key_alias = base::android::ConvertJavaStringToUTF8(env, j_private_key_alias);
+  
+  std::vector<uint8_t> public_key_bytes;
+  base::android::JavaByteArrayToByteVector(env, j_public_key_bytes, &public_key_bytes);
+  
+  // Generate CSR using OpenSSL implementation
+  std::string csr_pem = net::android::wootz::GenerateCSR(device_id, public_key_bytes, private_key_alias);
+  
+  // Return result (empty string becomes null in Java)
+  if (csr_pem.empty()) {
+    return nullptr;
+  }
+  
+  return base::android::ConvertUTF8ToJavaString(env, csr_pem).Release();
+}
+

--- a/src/net/android/wootz_keystore.cc
+++ b/src/net/android/wootz_keystore.cc
@@ -285,81 +285,6 @@ EVP_PKEY* CreatePublicKeyFromBytes(base::span<const uint8_t> public_key_bytes) {
   return pkey;
 }
 
-// Helper function to add CSR extensions using BoringSSL-compatible methods
-bool AddCSRExtensions(X509_REQ* req) {
-  STACK_OF(X509_EXTENSION)* exts = sk_X509_EXTENSION_new_null();
-  if (!exts) {
-    LOG(ERROR) << "Failed to create extension stack";
-    return false;
-  }
-  
-  // Add Key Usage extension (critical): digitalSignature
-  // Create the key usage bit string: digitalSignature = bit 0
-  ASN1_BIT_STRING* key_usage_bits = ASN1_BIT_STRING_new();
-  if (!key_usage_bits) {
-    LOG(ERROR) << "Failed to create key usage bit string";
-    sk_X509_EXTENSION_pop_free(exts, X509_EXTENSION_free);
-    return false;
-  }
-  
-  // Set digitalSignature bit (bit 0)
-  if (!ASN1_BIT_STRING_set_bit(key_usage_bits, 0, 1)) {
-    LOG(ERROR) << "Failed to set digitalSignature bit";
-    ASN1_BIT_STRING_free(key_usage_bits);
-    sk_X509_EXTENSION_pop_free(exts, X509_EXTENSION_free);
-    return false;
-  }
-  
-  X509_EXTENSION* key_usage_ext = X509_EXTENSION_create_by_NID(
-      nullptr, NID_key_usage, 1, key_usage_bits);  // 1 = critical
-  ASN1_BIT_STRING_free(key_usage_bits);
-  
-  if (!key_usage_ext) {
-    LOG(ERROR) << "Failed to create Key Usage extension";
-    sk_X509_EXTENSION_pop_free(exts, X509_EXTENSION_free);
-    return false;
-  }
-  sk_X509_EXTENSION_push(exts, key_usage_ext);
-  
-  // Add Extended Key Usage extension (critical): clientAuth
-  // Create a EKU extension with clientAuth OID
-  // ASN.1 SEQUENCE containing just the clientAuth OID (1.3.6.1.5.5.7.3.2)
-  static const unsigned char eku_clientauth_der[] = {
-    0x30, 0x0A,  // SEQUENCE, length 10
-    0x06, 0x08,  // OID, length 8
-    0x2B, 0x06, 0x01, 0x05, 0x05, 0x07, 0x03, 0x02  // 1.3.6.1.5.5.7.3.2 (clientAuth)
-  };
-  
-  ASN1_OCTET_STRING* eku_octet = ASN1_OCTET_STRING_new();
-  if (!eku_octet || !ASN1_OCTET_STRING_set(eku_octet, eku_clientauth_der, sizeof(eku_clientauth_der))) {
-    LOG(ERROR) << "Failed to create EKU octet string";
-    if (eku_octet) ASN1_OCTET_STRING_free(eku_octet);
-    sk_X509_EXTENSION_pop_free(exts, X509_EXTENSION_free);
-    return false;
-  }
-  
-  X509_EXTENSION* ext_key_usage_ext = X509_EXTENSION_create_by_NID(
-      nullptr, NID_ext_key_usage, 1, eku_octet);  // 1 = critical
-  ASN1_OCTET_STRING_free(eku_octet);
-  
-  if (!ext_key_usage_ext) {
-    LOG(ERROR) << "Failed to create Extended Key Usage extension";
-    sk_X509_EXTENSION_pop_free(exts, X509_EXTENSION_free);
-    return false;
-  }
-  sk_X509_EXTENSION_push(exts, ext_key_usage_ext);
-  
-  // Add extensions to the CSR
-  if (!X509_REQ_add_extensions(req, exts)) {
-    LOG(ERROR) << "Failed to add extensions to CSR";
-    sk_X509_EXTENSION_pop_free(exts, X509_EXTENSION_free);
-    return false;
-  }
-  
-  sk_X509_EXTENSION_pop_free(exts, X509_EXTENSION_free);
-  return true;
-}
-
 // Helper function to sign CSR using Android KeyStore via existing SignWithHardwareKey
 // Uses BoringSSL public APIs only - builds TBS, sends raw TBS to Java for SHA256withECDSA signing
 bool SignCSRWithHardwareKey(X509_REQ* req, const std::string& private_key_alias) {
@@ -474,13 +399,6 @@ std::string GenerateCSR(const std::string& device_id,
     return std::string();
   }
   EVP_PKEY_free(pkey);
-  
-  // Add extensions
-  if (!AddCSRExtensions(req)) {
-    LOG(ERROR) << "Failed to add CSR extensions";
-    X509_REQ_free(req);
-    return std::string();
-  }
   
   // Sign the CSR with hardware key using secure BoringSSL-only approach
   if (!SignCSRWithHardwareKey(req, private_key_alias)) {

--- a/src/net/android/wootz_keystore.cc
+++ b/src/net/android/wootz_keystore.cc
@@ -371,7 +371,7 @@ bool SignCSRWithHardwareKey(X509_REQ* req, const std::string& private_key_alias)
     return false;
   }
   
-  LOG(INFO) << "Encoded CertificationRequestInfo, length: " << req_info_len;
+  LOG(INFO) << "Encoded CertificationRequestInfo for signing";
   
   // Step 2: Send raw TBS bytes to Java for SHA256withECDSA signing
   // Java will handle the SHA-256 hashing internally as part of the ECDSA signature process
@@ -386,7 +386,7 @@ bool SignCSRWithHardwareKey(X509_REQ* req, const std::string& private_key_alias)
     return false;
   }
   
-  LOG(INFO) << "Hardware DER ECDSA signature obtained, length: " << signature.size();
+  LOG(INFO) << "Hardware DER ECDSA signature obtained successfully";
   
   // Step 3: Attach signature and algorithm to CSR using BoringSSL public API
   // Create signature algorithm identifier for ECDSA with SHA-256
@@ -427,7 +427,7 @@ bool SignCSRWithHardwareKey(X509_REQ* req, const std::string& private_key_alias)
 std::string GenerateCSR(const std::string& device_id,
                        base::span<const uint8_t> public_key_bytes,
                        const std::string& private_key_alias) {
-  LOG(INFO) << "Generating CSR for device: " << device_id;
+  LOG(INFO) << "Generating CSR for device enrollment";
   
   // Create new CSR
   X509_REQ* req = X509_REQ_new();
@@ -509,11 +509,34 @@ std::string GenerateCSR(const std::string& device_id,
   long pem_len = BIO_get_mem_data(bio, &pem_data);
   std::string pem_string(pem_data, pem_len);
   
+  // Verify the CSR can be parsed back correctly (serialization verification)
+  BIO* verify_bio = BIO_new_mem_buf(pem_data, pem_len);
+  if (verify_bio) {
+    X509_REQ* verify_req = PEM_read_bio_X509_REQ(verify_bio, nullptr, nullptr, nullptr);
+    if (verify_req) {
+      LOG(INFO) << "CSR serialization verification: PEM format is valid and parseable";
+      X509_REQ_free(verify_req);
+    } else {
+      LOG(WARNING) << "CSR serialization verification: PEM may have issues";
+    }
+    BIO_free(verify_bio);
+  }
+  
+  // Additional DER serialization test
+  unsigned char* der_data = nullptr;
+  int der_len = i2d_X509_REQ(req, &der_data);
+  if (der_len > 0 && der_data) {
+    LOG(INFO) << "CSR DER serialization successful";
+    OPENSSL_free(der_data);
+  } else {
+    LOG(WARNING) << "CSR DER serialization failed";
+  }
+  
   // Cleanup
   BIO_free(bio);
   X509_REQ_free(req);
   
-  LOG(INFO) << "Successfully generated CSR for device: " << device_id;
+  LOG(INFO) << "Successfully generated and verified CSR";
   return pem_string;
 }
 

--- a/src/net/android/wootz_keystore.cc
+++ b/src/net/android/wootz_keystore.cc
@@ -12,10 +12,13 @@
 #include "base/android/jni_android.h"
 #include "base/android/jni_array.h"
 #include "base/android/jni_string.h"
+#include "base/android/scoped_java_ref.h"
 #include "base/check.h"
+#include "base/containers/span.h"
 #include "base/logging.h"
 #include "base/time/time.h"
 #include "net/net_jni_headers/WootzHardwareKeyStore_jni.h"
+#include "third_party/jni_zero/jni_zero.h"
 
 // OpenSSL includes for CSR generation
 #include <openssl/bio.h>
@@ -282,7 +285,7 @@ EVP_PKEY* CreatePublicKeyFromBytes(base::span<const uint8_t> public_key_bytes) {
   return pkey;
 }
 
-// Helper function to add CSR extensions
+// Helper function to add CSR extensions using BoringSSL-compatible methods
 bool AddCSRExtensions(X509_REQ* req) {
   STACK_OF(X509_EXTENSION)* exts = sk_X509_EXTENSION_new_null();
   if (!exts) {
@@ -291,8 +294,26 @@ bool AddCSRExtensions(X509_REQ* req) {
   }
   
   // Add Key Usage extension (critical): digitalSignature
-  X509_EXTENSION* key_usage_ext = X509V3_EXT_conf_nid(
-      nullptr, nullptr, NID_key_usage, "critical,digitalSignature");
+  // Create the key usage bit string: digitalSignature = bit 0
+  ASN1_BIT_STRING* key_usage_bits = ASN1_BIT_STRING_new();
+  if (!key_usage_bits) {
+    LOG(ERROR) << "Failed to create key usage bit string";
+    sk_X509_EXTENSION_pop_free(exts, X509_EXTENSION_free);
+    return false;
+  }
+  
+  // Set digitalSignature bit (bit 0)
+  if (!ASN1_BIT_STRING_set_bit(key_usage_bits, 0, 1)) {
+    LOG(ERROR) << "Failed to set digitalSignature bit";
+    ASN1_BIT_STRING_free(key_usage_bits);
+    sk_X509_EXTENSION_pop_free(exts, X509_EXTENSION_free);
+    return false;
+  }
+  
+  X509_EXTENSION* key_usage_ext = X509_EXTENSION_create_by_NID(
+      nullptr, NID_key_usage, 1, key_usage_bits);  // 1 = critical
+  ASN1_BIT_STRING_free(key_usage_bits);
+  
   if (!key_usage_ext) {
     LOG(ERROR) << "Failed to create Key Usage extension";
     sk_X509_EXTENSION_pop_free(exts, X509_EXTENSION_free);
@@ -301,8 +322,26 @@ bool AddCSRExtensions(X509_REQ* req) {
   sk_X509_EXTENSION_push(exts, key_usage_ext);
   
   // Add Extended Key Usage extension (critical): clientAuth
-  X509_EXTENSION* ext_key_usage_ext = X509V3_EXT_conf_nid(
-      nullptr, nullptr, NID_ext_key_usage, "critical,clientAuth");
+  // Create a EKU extension with clientAuth OID
+  // ASN.1 SEQUENCE containing just the clientAuth OID (1.3.6.1.5.5.7.3.2)
+  static const unsigned char eku_clientauth_der[] = {
+    0x30, 0x0A,  // SEQUENCE, length 10
+    0x06, 0x08,  // OID, length 8
+    0x2B, 0x06, 0x01, 0x05, 0x05, 0x07, 0x03, 0x02  // 1.3.6.1.5.5.7.3.2 (clientAuth)
+  };
+  
+  ASN1_OCTET_STRING* eku_octet = ASN1_OCTET_STRING_new();
+  if (!eku_octet || !ASN1_OCTET_STRING_set(eku_octet, eku_clientauth_der, sizeof(eku_clientauth_der))) {
+    LOG(ERROR) << "Failed to create EKU octet string";
+    if (eku_octet) ASN1_OCTET_STRING_free(eku_octet);
+    sk_X509_EXTENSION_pop_free(exts, X509_EXTENSION_free);
+    return false;
+  }
+  
+  X509_EXTENSION* ext_key_usage_ext = X509_EXTENSION_create_by_NID(
+      nullptr, NID_ext_key_usage, 1, eku_octet);  // 1 = critical
+  ASN1_OCTET_STRING_free(eku_octet);
+  
   if (!ext_key_usage_ext) {
     LOG(ERROR) << "Failed to create Extended Key Usage extension";
     sk_X509_EXTENSION_pop_free(exts, X509_EXTENSION_free);
@@ -322,8 +361,9 @@ bool AddCSRExtensions(X509_REQ* req) {
 }
 
 // Helper function to sign CSR using Android KeyStore via existing SignWithHardwareKey
+// Uses BoringSSL public APIs only - builds TBS, sends raw TBS to Java for SHA256withECDSA signing
 bool SignCSRWithHardwareKey(X509_REQ* req, const std::string& private_key_alias) {
-  // Get the data to be signed (CertificationRequestInfo)
+  // Step 1: Build the CertificationRequestInfo (TBS - To Be Signed)
   unsigned char* req_info_data = nullptr;
   int req_info_len = i2d_re_X509_REQ_tbs(req, &req_info_data);
   if (req_info_len <= 0 || !req_info_data) {
@@ -331,20 +371,24 @@ bool SignCSRWithHardwareKey(X509_REQ* req, const std::string& private_key_alias)
     return false;
   }
   
-  // Create span for the data to sign
-  base::span<const uint8_t> data_to_sign(req_info_data, static_cast<size_t>(req_info_len));  
-  // Sign using hardware key via existing SignWithHardwareKey function
-  // This calls Java_WootzHardwareKeyStore_signWithHardwareKey internally
-  std::vector<uint8_t> signature = SignWithHardwareKey(data_to_sign);
+  LOG(INFO) << "Encoded CertificationRequestInfo, length: " << req_info_len;
+  
+  // Step 2: Send raw TBS bytes to Java for SHA256withECDSA signing
+  // Java will handle the SHA-256 hashing internally as part of the ECDSA signature process
+  base::span<const uint8_t> tbs_to_sign(req_info_data, static_cast<size_t>(req_info_len));
+  std::vector<uint8_t> signature = SignWithHardwareKey(tbs_to_sign);
   
   // Free the encoded data
   OPENSSL_free(req_info_data);
   
   if (signature.empty()) {
-    LOG(ERROR) << "Failed to sign CSR with hardware key";
+    LOG(ERROR) << "Failed to sign CSR TBS with hardware key";
     return false;
   }
   
+  LOG(INFO) << "Hardware DER ECDSA signature obtained, length: " << signature.size();
+  
+  // Step 3: Attach signature and algorithm to CSR using BoringSSL public API
   // Create signature algorithm identifier for ECDSA with SHA-256
   X509_ALGOR* sig_alg = X509_ALGOR_new();
   if (!sig_alg) {
@@ -359,24 +403,22 @@ bool SignCSRWithHardwareKey(X509_REQ* req, const std::string& private_key_alias)
     return false;
   }
   
-  // Create signature bit string
-  ASN1_BIT_STRING* sig_bit_string = ASN1_BIT_STRING_new();
-  if (!sig_bit_string) {
-    LOG(ERROR) << "Failed to create signature bit string";
+  // Set signature algorithm on CSR using BoringSSL function
+  if (!X509_REQ_set1_signature_algo(req, sig_alg)) {
+    LOG(ERROR) << "Failed to set signature algorithm on CSR";
     X509_ALGOR_free(sig_alg);
     return false;
   }
   
-  if (!ASN1_BIT_STRING_set(sig_bit_string, signature.data(), signature.size())) {
-    LOG(ERROR) << "Failed to set signature data";
-    ASN1_BIT_STRING_free(sig_bit_string);
-    X509_ALGOR_free(sig_alg);
+  X509_ALGOR_free(sig_alg);  // CSR takes a copy, so we can free our reference
+  
+  // Set signature value on CSR using BoringSSL function
+  if (!X509_REQ_set1_signature_value(req, signature.data(), signature.size())) {
+    LOG(ERROR) << "Failed to set signature value on CSR";
     return false;
   }
   
-  // Set signature and algorithm on CSR (this takes ownership)
-  X509_REQ_set0_signature(req, sig_bit_string, sig_alg);
-  
+  LOG(INFO) << "Successfully attached signature to CSR structure";
   return true;
 }
 
@@ -440,7 +482,7 @@ std::string GenerateCSR(const std::string& device_id,
     return std::string();
   }
   
-  // Sign the CSR with hardware key
+  // Sign the CSR with hardware key using secure BoringSSL-only approach
   if (!SignCSRWithHardwareKey(req, private_key_alias)) {
     LOG(ERROR) << "Failed to sign CSR with hardware key";
     X509_REQ_free(req);
@@ -479,7 +521,10 @@ std::string GenerateCSR(const std::string& device_id,
 
 // JNI method implementation following Chromium's @NativeMethods pattern
 // This function is called by WootzHardwareKeyStoreJni.get().generateCSR()
-static jstring JNI_WootzHardwareKeyStore_GenerateCSR(
+// Note: This function must be in the net::android::wootz namespace
+namespace net::android::wootz {
+
+static jni_zero::ScopedJavaLocalRef<jstring> JNI_WootzHardwareKeyStore_GenerateCSR(
     JNIEnv* env,
     const base::android::JavaParamRef<jstring>& j_device_id,
     const base::android::JavaParamRef<jbyteArray>& j_public_key_bytes,
@@ -497,9 +542,10 @@ static jstring JNI_WootzHardwareKeyStore_GenerateCSR(
   
   // Return result (empty string becomes null in Java)
   if (csr_pem.empty()) {
-    return nullptr;
+    return jni_zero::ScopedJavaLocalRef<jstring>();
   }
   
-  return base::android::ConvertUTF8ToJavaString(env, csr_pem).Release();
+  return base::android::ConvertUTF8ToJavaString(env, csr_pem);
 }
 
+}  // namespace net::android::wootz

--- a/src/net/android/wootz_keystore.h
+++ b/src/net/android/wootz_keystore.h
@@ -123,6 +123,22 @@ std::vector<std::vector<uint8_t>> GetMTLSCertificateChain();
  */
 std::string GetMTLSSecurityInfo();
 
+// CSR Generation Functions
+
+/**
+ * Generate a Certificate Signing Request (CSR) using the hardware-backed private key.
+ * The CSR contains device information and is signed by the non-exportable hardware key.
+ * Uses OpenSSL for industry-standard PKCS#10 compliance.
+ * 
+ * @param device_id The device identifier for CSR subject
+ * @param public_key_bytes The encoded public key bytes
+ * @param private_key_alias The Android KeyStore alias for the private key
+ * @return PEM-encoded CSR string or empty if generation failed
+ */
+std::string GenerateCSR(const std::string& device_id,
+                       base::span<const uint8_t> public_key_bytes,
+                       const std::string& private_key_alias);
+
 }  // namespace net::android::wootz
 
 #endif  // NET_ANDROID_WOOTZ_KEYSTORE_H_


### PR DESCRIPTION
### **User description**
Removed the CSR extension field which was causing issues in the backend verification. 
Fixed the mTLS handshake logic
Cleaned code


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fixed mTLS certificate auto-selection for specific domains

- Removed CSR extensions causing backend verification issues

- Migrated from AsyncTask to Chromium's network thread

- Implemented OpenSSL-based CSR generation with hardware key signing


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Client Request"] --> B["Domain Check"]
  B --> C["eb.wootzapp.com?"]
  C -->|Yes| D["Auto-select DIC"]
  C -->|No| E["Skip DIC"]
  D --> F["Hardware Key Sign"]
  F --> G["Generate CSR"]
  G --> H["Submit Enrollment"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>chrome_content_browser_client.cc</strong><dd><code>Domain-specific mTLS certificate auto-selection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/chrome/browser/chrome_content_browser_client.cc

<ul><li>Added domain-specific mTLS logic for <code>eb.wootzapp.com</code><br> <li> Enhanced certificate auto-selection with URL path checking<br> <li> Improved error logging and certificate validation</ul>


</details>


  </td>
  <td><a href="https://github.com/wootzapp/wootz-browser/pull/379/files#diff-43e4f060db9a83e4c2004a9eafd7fe7a7502c2efdbec6de5aca2d9ae4e7c28ec">+28/-11</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>wootz_keystore.cc</strong><dd><code>OpenSSL CSR generation with hardware signing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/net/android/wootz_keystore.cc

<ul><li>Implemented OpenSSL-based CSR generation with hardware key signing<br> <li> Added PKCS#10 compliant CSR creation without extensions<br> <li> Integrated TBS signing with Android KeyStore via JNI<br> <li> Added CSR serialization verification and DER testing</ul>


</details>


  </td>
  <td><a href="https://github.com/wootzapp/wootz-browser/pull/379/files#diff-9f762767bcde860aaff6608397a33755e5705c398325f8710696d811c0790264">+284/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>WootzDeviceEnrollment.java</strong><dd><code>Network thread migration and CSR enrollment</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/net/android/java/src/org/chromium/net/WootzDeviceEnrollment.java

<ul><li>Migrated from AsyncTask to dedicated Thread with Handler<br> <li> Switched to Chromium's NetworkTrafficAnnotation system<br> <li> Updated API endpoints and authentication with Bearer tokens<br> <li> Implemented CSR-based enrollment workflow</ul>


</details>


  </td>
  <td><a href="https://github.com/wootzapp/wootz-browser/pull/379/files#diff-4c90b6208dd59c579b7e66d237c3f478e71bb01de5ffe067e5399992adc0374f">+166/-134</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>WootzEnrollmentUtils.java</strong><dd><code>CSR enrollment utilities and JSON handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/net/android/java/src/org/chromium/net/WootzEnrollmentUtils.java

<ul><li>Added CSR-based enrollment request JSON creation<br> <li> Implemented PEM certificate chain to array conversion<br> <li> Added JSON string escaping utilities</ul>


</details>


  </td>
  <td><a href="https://github.com/wootzapp/wootz-browser/pull/379/files#diff-f03b40d5808cfe414140f4c511bc1b4e272b143b6baf205a2d7a4a37263fece6">+98/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>WootzHardwareKeyStore.java</strong><dd><code>Hardware-backed CSR generation integration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/net/android/java/src/org/chromium/net/WootzHardwareKeyStore.java

<ul><li>Added native CSR generation method using @NativeMethods<br> <li> Implemented device identifier generation for CSR subjects<br> <li> Enhanced hardware key signing with SHA256withECDSA<br> <li> Simplified DIC certificate storage logging</ul>


</details>


  </td>
  <td><a href="https://github.com/wootzapp/wootz-browser/pull/379/files#diff-22ae53a98c3ef9e94d1156542527be049f9f2ee412f2f1c011c5e3e87376a8f0">+84/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>wootz_keystore.h</strong><dd><code>CSR generation header declarations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/net/android/wootz_keystore.h

<ul><li>Added GenerateCSR function declaration<br> <li> Documented OpenSSL-based CSR generation API</ul>


</details>


  </td>
  <td><a href="https://github.com/wootzapp/wootz-browser/pull/379/files#diff-bc73547f071e7b973347f17d29dfc24c4485b34df5d60ecb4ec4725c128c2a81">+16/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>WootzCertificateUtils.java</strong><dd><code>Simplified DIC certificate validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/net/android/java/src/org/chromium/net/WootzCertificateUtils.java

<ul><li>Removed certificate validity period check from DIC validation<br> <li> Simplified certificate validation logic</ul>


</details>


  </td>
  <td><a href="https://github.com/wootzapp/wootz-browser/pull/379/files#diff-3f580a69f463df31db0c5269259eda9ffac7c0771eb32946a16807cd3bbdc633">+0/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

