### PR TITLE
Modified Floating Action Button logic to open the Wootz AI

### DIFF
--- a/src/build/config/android/config.gni
+++ b/src/build/config/android/config.gni
@@ -223,10 +223,10 @@ if (is_android || is_chromeos) {
     android_default_version_name = "Developer Build"
 
     # Forced Android versionCode
-    android_override_version_code = "136"
+    android_override_version_code = "140"
 
     # Forced Android versionName
-    android_override_version_name = "1.04"
+    android_override_version_name = "1.06"
 
     # The path to the keystore to use for signing builds.
     android_keystore_path = default_android_keystore_path

--- a/src/chrome/android/java/src/org/chromium/chrome/browser/app/ChromeActivity.java
+++ b/src/chrome/android/java/src/org/chromium/chrome/browser/app/ChromeActivity.java
@@ -89,6 +89,7 @@ import org.chromium.chrome.browser.ActivityTabProvider;
 import org.chromium.chrome.browser.ActivityUtils;
 import org.chromium.chrome.browser.extensions.ExtensionInfo;
 import org.chromium.chrome.browser.extensions.Extensions;
+import org.chromium.chrome.browser.extensions.OpenExtensionsById;
 import org.chromium.chrome.browser.extensions.WootzBridge;
 import org.chromium.chrome.browser.AppHooks;
 import org.chromium.chrome.browser.ChromeActivitySessionTracker;
@@ -963,8 +964,8 @@ public abstract class ChromeActivity<C extends ChromeActivityComponent>
 
                         case MotionEvent.ACTION_UP:
                             if (!isDragging) {
-                                showAiChatOptionsMenu(view);
-                                
+                                // showAiChatOptionsMenu(view);
+                                openWootzAi(view);
                             }
                             isDragging = false;
                             return true;
@@ -1023,15 +1024,19 @@ public abstract class ChromeActivity<C extends ChromeActivityComponent>
             return false;
         }
 
-        boolean isOnSearchPage = false;
-        if (currentTab.getUrl() != null) {
-            isOnSearchPage = isSearchPage(currentTab.getUrl().getSpec());
-        }
+        // boolean isOnSearchPage = false;
+        // if (currentTab.getUrl() != null) {
+        //     isOnSearchPage = isSearchPage(currentTab.getUrl().getSpec());
+        // }
+
+        // Map<String, String> extensionFeatures = getExtensionFeaturesMap();
+        // boolean hasExtensionFeatures = !extensionFeatures.isEmpty();
+
+        // return isOnSearchPage || hasExtensionFeatures;
 
         Map<String, String> extensionFeatures = getExtensionFeaturesMap();
-        boolean hasExtensionFeatures = !extensionFeatures.isEmpty();
-
-        return isOnSearchPage || hasExtensionFeatures;
+        boolean hasWootzAiFeature = extensionFeatures.containsKey("Wootz AI");
+        return hasWootzAiFeature;
     }
 
     public void updateFabVisibility() {
@@ -1043,6 +1048,20 @@ public abstract class ChromeActivity<C extends ChromeActivityComponent>
             if (shouldShow) {
                 resetFabOpacity();
             }
+        }
+    }
+
+    private void openWootzAi(View anchorView) {
+        Tab currentTab = getActivityTab();
+        Map<String, String> extensionFeatures = getExtensionFeaturesMap();
+        String featureKey = "Wootz AI";
+        if (currentTab != null && extensionFeatures.containsKey(featureKey)) {
+            String extensionId = extensionFeatures.get(featureKey);
+            OpenExtensionsById openExtById = new OpenExtensionsById();
+            openExtById.openExtensionById(extensionId);
+        } else {
+            updateFabVisibility();
+            Log.e(TAG, "Wootz AI feature not found in installed extensions.");
         }
     }
 


### PR DESCRIPTION
### **User description**
### This PR updates the behavior of the Floating Action Button (FAB) so that it now directly opens the Wootz AI extension when clicked, instead of displaying a menu with multiple options. 
- The FAB will only be visible if the Wootz AI feature is available in the installed extensions, providing a more streamlined and focused user experience.


___

### **PR Type**
Enhancement


___

### **Description**
- Modified FAB to directly open Wootz AI extension

- Updated visibility logic to check for Wootz AI feature

- Removed menu display in favor of direct extension launch

- Incremented version code and name


___

### Diagram Walkthrough


```mermaid
flowchart LR
  FAB["FAB Click"] --> Check["Check Wootz AI Available"] --> Open["Open Wootz AI Extension"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ChromeActivity.java</strong><dd><code>FAB behavior changed to open Wootz AI directly</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/chrome/android/java/src/org/chromium/chrome/browser/app/ChromeActivity.java

<ul><li>Added import for <code>OpenExtensionsById</code> class<br> <li> Modified FAB click handler to call <code>openWootzAi()</code> instead of showing <br>menu<br> <li> Updated <code>shouldShowFab()</code> to only check for Wootz AI feature <br>availability<br> <li> Added new <code>openWootzAi()</code> method to directly launch Wootz AI extension</ul>


</details>


  </td>
  <td><a href="https://github.com/wootzapp/wootz-browser/pull/381/files#diff-c8acd06c7d46dc25f58ba07fb743c8b5d67d7da310275e70e1cdd7abe1bbdb36">+28/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.gni</strong><dd><code>Version code and name incremented</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/build/config/android/config.gni

<ul><li>Updated <code>android_override_version_code</code> from "136" to "140"<br> <li> Updated <code>android_override_version_name</code> from "1.04" to "1.06"</ul>


</details>


  </td>
  <td><a href="https://github.com/wootzapp/wootz-browser/pull/381/files#diff-80421383edd2d63a6a76679bee5bfea7363eaaf812df711a3513853f246fb4cc">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

