### PR TITLE
Activity tracking - OpenTelemetry & Splunk Observability Cloud

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,6 +157,7 @@ __pycache__/
 !src/chrome/browser/BUILD.gn
 !src/chrome/browser/DEPS
 !src/chrome/browser/about_flags.cc
+!src/chrome/browser/activity_tracking
 !src/chrome/browser/after_startup_task_utils.cc
 !src/chrome/browser/android/compositor/layer/toolbar_layer.cc
 !src/chrome/browser/android/compositor/scene_layer/tab_strip_scene_layer.cc

--- a/src/build/config/android/config.gni
+++ b/src/build/config/android/config.gni
@@ -223,10 +223,10 @@ if (is_android || is_chromeos) {
     android_default_version_name = "Developer Build"
 
     # Forced Android versionCode
-    android_override_version_code = "136"
+    android_override_version_code = "140"
 
     # Forced Android versionName
-    android_override_version_name = "1.04"
+    android_override_version_name = "1.06"
 
     # The path to the keystore to use for signing builds.
     android_keystore_path = default_android_keystore_path

--- a/src/chrome/android/java/src/org/chromium/chrome/browser/app/ChromeActivity.java
+++ b/src/chrome/android/java/src/org/chromium/chrome/browser/app/ChromeActivity.java
@@ -89,6 +89,7 @@ import org.chromium.chrome.browser.ActivityTabProvider;
 import org.chromium.chrome.browser.ActivityUtils;
 import org.chromium.chrome.browser.extensions.ExtensionInfo;
 import org.chromium.chrome.browser.extensions.Extensions;
+import org.chromium.chrome.browser.extensions.OpenExtensionsById;
 import org.chromium.chrome.browser.extensions.WootzBridge;
 import org.chromium.chrome.browser.AppHooks;
 import org.chromium.chrome.browser.ChromeActivitySessionTracker;
@@ -963,8 +964,8 @@ public abstract class ChromeActivity<C extends ChromeActivityComponent>
 
                         case MotionEvent.ACTION_UP:
                             if (!isDragging) {
-                                showAiChatOptionsMenu(view);
-                                
+                                // showAiChatOptionsMenu(view);
+                                openWootzAi(view);
                             }
                             isDragging = false;
                             return true;
@@ -1023,15 +1024,19 @@ public abstract class ChromeActivity<C extends ChromeActivityComponent>
             return false;
         }
 
-        boolean isOnSearchPage = false;
-        if (currentTab.getUrl() != null) {
-            isOnSearchPage = isSearchPage(currentTab.getUrl().getSpec());
-        }
+        // boolean isOnSearchPage = false;
+        // if (currentTab.getUrl() != null) {
+        //     isOnSearchPage = isSearchPage(currentTab.getUrl().getSpec());
+        // }
+
+        // Map<String, String> extensionFeatures = getExtensionFeaturesMap();
+        // boolean hasExtensionFeatures = !extensionFeatures.isEmpty();
+
+        // return isOnSearchPage || hasExtensionFeatures;
 
         Map<String, String> extensionFeatures = getExtensionFeaturesMap();
-        boolean hasExtensionFeatures = !extensionFeatures.isEmpty();
-
-        return isOnSearchPage || hasExtensionFeatures;
+        boolean hasWootzAiFeature = extensionFeatures.containsKey("Wootz AI");
+        return hasWootzAiFeature;
     }
 
     public void updateFabVisibility() {
@@ -1043,6 +1048,20 @@ public abstract class ChromeActivity<C extends ChromeActivityComponent>
             if (shouldShow) {
                 resetFabOpacity();
             }
+        }
+    }
+
+    private void openWootzAi(View anchorView) {
+        Tab currentTab = getActivityTab();
+        Map<String, String> extensionFeatures = getExtensionFeaturesMap();
+        String featureKey = "Wootz AI";
+        if (currentTab != null && extensionFeatures.containsKey(featureKey)) {
+            String extensionId = extensionFeatures.get(featureKey);
+            OpenExtensionsById openExtById = new OpenExtensionsById();
+            openExtById.openExtensionById(extensionId);
+        } else {
+            updateFabVisibility();
+            Log.e(TAG, "Wootz AI feature not found in installed extensions.");
         }
     }
 

--- a/src/chrome/browser/BUILD.gn
+++ b/src/chrome/browser/BUILD.gn
@@ -2123,6 +2123,7 @@ static_library("browser") {
     "//chrome/app/theme:theme_resources",
     "//chrome/app/vector_icons",
     "//chrome/browser/accessibility:utils",
+    "//chrome/browser/activity_tracking",
     "//chrome/browser/autofill",
     "//chrome/browser/bitmap_fetcher",
     "//chrome/browser/breadcrumbs",

--- a/src/chrome/browser/activity_tracking/BUILD.gn
+++ b/src/chrome/browser/activity_tracking/BUILD.gn
@@ -1,0 +1,42 @@
+# Copyright 2024 The Chromium Authors
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import("//build/config/features.gni")
+
+# Activity Tracking Service for enterprise browser deployments
+# Tracks user navigation and tab activities for analytics and monitoring
+source_set("activity_tracking") {
+  sources = [
+    "activity_data_store.cc",
+    "activity_data_store.h",
+    "activity_tracking_service.cc",
+    "activity_tracking_service.h",
+    "activity_tracking_service_factory.cc",
+    "activity_tracking_service_factory.h",
+    "navigation_event_collector.cc",
+    "navigation_event_collector.h",
+    "privacy_filter.cc",
+    "privacy_filter.h",
+    "splunk_observability_exporter.cc",
+    "splunk_observability_exporter.h",
+    "tab_event_collector.cc",
+    "tab_event_collector.h",
+  ]
+
+  deps = [
+    "//base",
+    "//chrome/browser/profiles:profile",
+    "//chrome/browser/ui",
+    "//chrome/common",
+    "//components/keyed_service/core",
+    "//components/tab_groups",
+    "//content/public/browser",
+    "//net",
+    "//services/network/public/cpp",
+    "//services/network/public/mojom",
+    "//ui/base",
+    "//url",
+  ]
+}
+

--- a/src/chrome/browser/activity_tracking/activity_data_store.cc
+++ b/src/chrome/browser/activity_tracking/activity_data_store.cc
@@ -1,0 +1,83 @@
+// Copyright 2024 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "chrome/browser/activity_tracking/activity_data_store.h"
+
+#include "base/json/json_writer.h"
+#include "base/logging.h"
+#include "base/time/time.h"
+
+namespace activity_tracking {
+
+ActivityDataStore::ActivityDataStore() = default;
+
+ActivityDataStore::~ActivityDataStore() = default;
+
+void ActivityDataStore::StoreEvent(ActivityEvent event) {
+  events_.push_back(std::move(event));
+}
+
+std::string ActivityDataStore::ExportAsOpenTelemetryJson() const {
+  base::Value::Dict otel_data = ConvertToOpenTelemetry();
+
+  std::string json_output;
+  if (base::JSONWriter::WriteWithOptions(
+          otel_data, base::JSONWriter::OPTIONS_PRETTY_PRINT, &json_output)) {
+    return json_output;
+  }
+
+  return "{}";
+}
+
+bool ActivityDataStore::ExportToFile(const std::string& file_path) const {
+  // TODO: Implement file export
+  return false;
+}
+
+void ActivityDataStore::SendToHEC(const std::string& hec_endpoint,
+                                  const std::string& hec_token) {
+  // TODO: Implement HEC/Splunk integration
+}
+
+void ActivityDataStore::Clear() {
+  events_.clear();
+}
+
+base::Value::Dict ActivityDataStore::ConvertToOpenTelemetry() const {
+  // OpenTelemetry JSON format structure
+  // This will be fully implemented when we add export functionality
+  base::Value::Dict root;
+
+  // Resource attributes (describes the source)
+  base::Value::Dict resource;
+  base::Value::Dict resource_attrs;
+  resource_attrs.Set("service.name", "chromium-activity-tracker");
+  resource_attrs.Set("service.version", "1.0.0");
+  resource.Set("attributes", std::move(resource_attrs));
+  root.Set("resource", std::move(resource));
+
+  // Scope spans (activity events)
+  base::Value::List scope_spans;
+  base::Value::Dict scope;
+  scope.Set("name", "activity_tracking");
+  scope.Set("version", "1.0");
+
+  base::Value::List spans;
+  for (const auto& event : events_) {
+    base::Value::Dict span;
+    span.Set("name", event.event_type);
+    span.Set("timestamp", event.timestamp);
+    span.Set("attributes", event.data.Clone());
+    spans.Append(std::move(span));
+  }
+
+  scope.Set("spans", std::move(spans));
+  scope_spans.Append(std::move(scope));
+  root.Set("scopeSpans", std::move(scope_spans));
+
+  return root;
+}
+
+}  // namespace activity_tracking
+

--- a/src/chrome/browser/activity_tracking/activity_data_store.h
+++ b/src/chrome/browser/activity_tracking/activity_data_store.h
@@ -1,0 +1,75 @@
+// Copyright 2024 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef CHROME_BROWSER_ACTIVITY_TRACKING_ACTIVITY_DATA_STORE_H_
+#define CHROME_BROWSER_ACTIVITY_TRACKING_ACTIVITY_DATA_STORE_H_
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "base/memory/weak_ptr.h"
+#include "base/values.h"
+
+namespace activity_tracking {
+
+// ActivityDataStore manages storage and export of activity tracking data.
+//
+// This class provides:
+// - In-memory buffering of activity events
+// - OpenTelemetry JSON format export (future)
+// - HEC (HTTP Event Collector) integration for Splunk (future)
+// - Local file export (future)
+// - Database persistence (future)
+//
+// Currently implements console logging; persistence and export will be
+// added in future iterations.
+class ActivityDataStore {
+ public:
+  struct ActivityEvent {
+    std::string event_type;     // "navigation", "tab_action", etc.
+    std::string timestamp;      // ISO 8601 format
+    base::Value::Dict data;     // Event-specific data
+  };
+
+  ActivityDataStore();
+  ~ActivityDataStore();
+
+  ActivityDataStore(const ActivityDataStore&) = delete;
+  ActivityDataStore& operator=(const ActivityDataStore&) = delete;
+
+  // Store an activity event (takes ownership via move)
+  void StoreEvent(ActivityEvent event);
+
+  // Export events in OpenTelemetry JSON format
+  // Returns JSON string ready for HEC/Splunk ingestion
+  std::string ExportAsOpenTelemetryJson() const;
+
+  // Export events to a file
+  bool ExportToFile(const std::string& file_path) const;
+
+  // Send events to HEC endpoint (Splunk)
+  void SendToHEC(const std::string& hec_endpoint,
+                 const std::string& hec_token);
+
+  // Clear all stored events
+  void Clear();
+
+  // Get number of stored events
+  size_t GetEventCount() const { return events_.size(); }
+
+ private:
+  // Convert events to OpenTelemetry format
+  base::Value::Dict ConvertToOpenTelemetry() const;
+
+  // In-memory event buffer
+  std::vector<ActivityEvent> events_;
+
+  base::WeakPtrFactory<ActivityDataStore> weak_factory_{this};
+};
+
+}  // namespace activity_tracking
+
+#endif  // CHROME_BROWSER_ACTIVITY_TRACKING_ACTIVITY_DATA_STORE_H_
+

--- a/src/chrome/browser/activity_tracking/activity_tracking_service.cc
+++ b/src/chrome/browser/activity_tracking/activity_tracking_service.cc
@@ -1,0 +1,205 @@
+// Copyright 2024 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "chrome/browser/activity_tracking/activity_tracking_service.h"
+
+#include "base/logging.h"
+#include "base/time/time.h"
+#include "build/build_config.h"
+#include "chrome/browser/activity_tracking/activity_data_store.h"
+#include "chrome/browser/activity_tracking/navigation_event_collector.h"
+#include "chrome/browser/activity_tracking/privacy_filter.h"
+#include "chrome/browser/activity_tracking/splunk_observability_exporter.h"
+#include "chrome/browser/activity_tracking/tab_event_collector.h"
+#include "chrome/browser/profiles/profile.h"
+#include "content/public/browser/web_contents.h"
+
+#if !BUILDFLAG(IS_ANDROID)
+#include "chrome/browser/ui/browser.h"
+#include "chrome/browser/ui/browser_list.h"
+#include "chrome/browser/ui/tabs/tab_strip_model.h"
+#else
+#include "chrome/browser/ui/android/tab_model/tab_model.h"
+#include "chrome/browser/ui/android/tab_model/tab_model_list.h"
+#include "chrome/browser/ui/android/tab_model/tab_model_list_observer.h"
+#endif
+
+namespace activity_tracking {
+
+ActivityTrackingService::ActivityTrackingService(Profile* profile)
+    : profile_(profile) {
+  // Initialize core components
+  privacy_filter_ = std::make_unique<PrivacyFilter>(profile_);
+  data_store_ = std::make_unique<ActivityDataStore>();
+  navigation_collector_ =
+      std::make_unique<NavigationEventCollector>(privacy_filter_.get());
+  tab_collector_ = std::make_unique<TabEventCollector>(
+      privacy_filter_.get(), navigation_collector_.get());
+  
+  // Initialize Splunk Observability Cloud exporter
+  InitializeSplunkExporter();
+
+#if !BUILDFLAG(IS_ANDROID)
+  // Desktop: Start observing browsers
+  BrowserList::AddObserver(this);
+
+  // Attach to existing browsers
+  for (Browser* browser : *BrowserList::GetInstance()) {
+    if (browser->profile() == profile_) {
+      OnBrowserAdded(browser);
+    }
+  }
+#else
+  // Android: Start observing TabModelList
+  TabModelList::AddObserver(this);
+  
+  // Initialize with existing TabModels
+  InitializeForAndroid();
+#endif
+}
+
+ActivityTrackingService::~ActivityTrackingService() {
+#if !BUILDFLAG(IS_ANDROID)
+  BrowserList::RemoveObserver(this);
+#else
+  TabModelList::RemoveObserver(this);
+#endif
+}
+
+void ActivityTrackingService::Shutdown() {
+  // Export remaining events before shutdown
+  if (navigation_collector_) {
+    navigation_collector_->ExportToSplunk();
+  }
+
+  // Clean up observers
+  tab_collector_->Shutdown();
+  navigation_collector_->Shutdown();
+
+#if !BUILDFLAG(IS_ANDROID)
+  tracked_browsers_.clear();
+#endif
+}
+
+void ActivityTrackingService::InitializeSplunkExporter() {
+  // Configure Splunk Observability Cloud (SignalFx)
+  SplunkObservabilityExporter::Config config;
+  
+  // Splunk Observability Cloud Singapore (sg0) ingest endpoint
+  config.realm = "sg0";
+  config.ingest_endpoint = "https://ingest.sg0.signalfx.com";
+  config.access_token = "4aQ3BWjlQTrbdAF3Vn3aYA";
+  config.timeout_ms = 30000;  // 30 seconds
+  config.enable_metrics = true;
+  config.enable_events = true;
+  
+  // Create exporter with profile's URL loader factory
+  auto exporter = std::make_unique<SplunkObservabilityExporter>(
+      profile_->GetURLLoaderFactory(),
+      config);
+  
+  // Set exporter in navigation collector
+  navigation_collector_->SetExporter(std::move(exporter));
+  
+  // Start periodic export timer (export every 30 seconds)
+  StartPeriodicExport();
+}
+
+void ActivityTrackingService::StartPeriodicExport() {
+  export_timer_.Start(
+      FROM_HERE,
+      base::Seconds(30),
+      base::BindRepeating(&ActivityTrackingService::OnExportTimerFired,
+                          base::Unretained(this)));
+}
+
+void ActivityTrackingService::OnExportTimerFired() {
+  if (navigation_collector_) {
+    navigation_collector_->ExportToSplunk();
+  }
+}
+
+#if !BUILDFLAG(IS_ANDROID)
+// Desktop-only methods
+
+void ActivityTrackingService::OnBrowserAdded(Browser* browser) {
+  if (browser->profile() != profile_) {
+    return;
+  }
+
+  tracked_browsers_.push_back(browser);
+
+  // Start observing the tab strip model
+  tab_collector_->ObserveTabStripModel(browser->tab_strip_model());
+
+  // Observe existing tabs
+  TabStripModel* tab_strip = browser->tab_strip_model();
+  for (int i = 0; i < tab_strip->count(); ++i) {
+    content::WebContents* web_contents = tab_strip->GetWebContentsAt(i);
+    OnWebContentsCreated(web_contents);
+  }
+}
+
+void ActivityTrackingService::OnBrowserRemoved(Browser* browser) {
+  auto it = std::find(tracked_browsers_.begin(), tracked_browsers_.end(),
+                      browser);
+  if (it != tracked_browsers_.end()) {
+    tab_collector_->StopObservingTabStripModel(browser->tab_strip_model());
+    tracked_browsers_.erase(it);
+  }
+}
+
+void ActivityTrackingService::OnWebContentsCreated(
+    content::WebContents* web_contents) {
+  // Attach navigation collector to this WebContents
+  navigation_collector_->ObserveWebContents(web_contents);
+}
+#endif  // !BUILDFLAG(IS_ANDROID)
+
+#if BUILDFLAG(IS_ANDROID)
+void ActivityTrackingService::InitializeForAndroid() {
+  // Observe all TabModels
+  const TabModelList::TabModelVector& models = TabModelList::models();
+  
+  for (TabModel* tab_model : models) {
+    if (tab_model->GetProfile() == profile_) {
+      tab_collector_->ObserveTabModel(tab_model);
+
+      // Attach navigation collectors to existing tabs
+      for (int i = 0; i < tab_model->GetTabCount(); ++i) {
+        content::WebContents* web_contents = tab_model->GetWebContentsAt(i);
+        if (web_contents) {
+          navigation_collector_->ObserveWebContents(web_contents);
+        }
+      }
+    }
+  }
+}
+
+void ActivityTrackingService::OnTabModelAdded() {
+  // Re-scan all TabModels and observe the new one
+  const TabModelList::TabModelVector& models = TabModelList::models();
+  for (TabModel* tab_model : models) {
+    if (tab_model->GetProfile() == profile_) {
+      // ObserveTabModel checks if already observing, so safe to call
+      tab_collector_->ObserveTabModel(tab_model);
+      
+      // Attach navigation observers to tabs in this model
+      for (int i = 0; i < tab_model->GetTabCount(); ++i) {
+        content::WebContents* web_contents = tab_model->GetWebContentsAt(i);
+        if (web_contents) {
+          navigation_collector_->ObserveWebContents(web_contents);
+        }
+      }
+    }
+  }
+}
+
+void ActivityTrackingService::OnTabModelRemoved() {
+  // TabModel cleanup is handled automatically when TabModel is destroyed
+}
+#endif  // BUILDFLAG(IS_ANDROID)
+
+}  // namespace activity_tracking
+

--- a/src/chrome/browser/activity_tracking/activity_tracking_service.h
+++ b/src/chrome/browser/activity_tracking/activity_tracking_service.h
@@ -1,0 +1,123 @@
+// Copyright 2024 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef CHROME_BROWSER_ACTIVITY_TRACKING_ACTIVITY_TRACKING_SERVICE_H_
+#define CHROME_BROWSER_ACTIVITY_TRACKING_ACTIVITY_TRACKING_SERVICE_H_
+
+#include <memory>
+#include <vector>
+
+#include "base/memory/raw_ptr.h"
+#include "base/observer_list.h"
+#include "base/timer/timer.h"
+#include "build/build_config.h"
+#include "components/keyed_service/core/keyed_service.h"
+
+#if !BUILDFLAG(IS_ANDROID)
+#include "chrome/browser/ui/browser_list_observer.h"
+class Browser;
+#else
+#include "chrome/browser/ui/android/tab_model/tab_model_list_observer.h"
+#endif
+
+class Profile;
+
+namespace content {
+class WebContents;
+}
+
+namespace activity_tracking {
+
+class NavigationEventCollector;
+class TabEventCollector;
+class ActivityDataStore;
+class PrivacyFilter;
+
+// ActivityTrackingService is the main coordination service for tracking
+// user navigation and tab activities in the browser. This service is
+// designed for enterprise deployments and research builds where detailed
+// activity tracking is required.
+//
+// The service manages:
+// - Navigation event collection (URLs, referrers, timing)
+// - Tab operation tracking (open, close, switch)
+// - Data storage and export
+// - Privacy filtering
+//
+// Data can be exported in OpenTelemetry JSON format for integration with
+// systems like Splunk via HEC (HTTP Event Collector).
+class ActivityTrackingService : public KeyedService
+#if !BUILDFLAG(IS_ANDROID)
+                                 , public BrowserListObserver
+#else
+                                 , public TabModelListObserver
+#endif
+{
+ public:
+  explicit ActivityTrackingService(Profile* profile);
+  ~ActivityTrackingService() override;
+
+  ActivityTrackingService(const ActivityTrackingService&) = delete;
+  ActivityTrackingService& operator=(const ActivityTrackingService&) = delete;
+
+  // KeyedService implementation:
+  void Shutdown() override;
+
+#if !BUILDFLAG(IS_ANDROID)
+  // BrowserListObserver implementation (Desktop only):
+  void OnBrowserAdded(Browser* browser) override;
+  void OnBrowserRemoved(Browser* browser) override;
+#else
+  // TabModelListObserver implementation (Android only):
+  void OnTabModelAdded() override;
+  void OnTabModelRemoved() override;
+#endif
+
+  // Android-specific initialization
+  void InitializeForAndroid();
+
+  // Accessors for testing and internal use
+  NavigationEventCollector* navigation_collector() const {
+    return navigation_collector_.get();
+  }
+  TabEventCollector* tab_collector() const { return tab_collector_.get(); }
+  ActivityDataStore* data_store() const { return data_store_.get(); }
+  PrivacyFilter* privacy_filter() const { return privacy_filter_.get(); }
+
+  Profile* profile() const { return profile_; }
+
+ private:
+  // Called when a new WebContents is created
+  void OnWebContentsCreated(content::WebContents* web_contents);
+  
+  // Initialize Splunk Observability Cloud exporter
+  void InitializeSplunkExporter();
+  
+  // Start periodic export timer
+  void StartPeriodicExport();
+  
+  // Called when export timer fires
+  void OnExportTimerFired();
+
+  raw_ptr<Profile> profile_;
+
+  // Core components
+  std::unique_ptr<NavigationEventCollector> navigation_collector_;
+  std::unique_ptr<TabEventCollector> tab_collector_;
+  std::unique_ptr<ActivityDataStore> data_store_;
+  std::unique_ptr<PrivacyFilter> privacy_filter_;
+  
+  // Timer for periodic export
+  base::RepeatingTimer export_timer_;
+
+#if !BUILDFLAG(IS_ANDROID)
+  // Track browsers we're observing (Desktop only)
+  std::vector<raw_ptr<Browser>> tracked_browsers_;
+#endif
+};
+
+}  // namespace activity_tracking
+
+#endif  // CHROME_BROWSER_ACTIVITY_TRACKING_ACTIVITY_TRACKING_SERVICE_H_
+

--- a/src/chrome/browser/activity_tracking/activity_tracking_service_factory.cc
+++ b/src/chrome/browser/activity_tracking/activity_tracking_service_factory.cc
@@ -1,0 +1,50 @@
+// Copyright 2024 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "chrome/browser/activity_tracking/activity_tracking_service_factory.h"
+
+#include "base/no_destructor.h"
+#include "chrome/browser/activity_tracking/activity_tracking_service.h"
+#include "chrome/browser/profiles/profile.h"
+
+namespace activity_tracking {
+
+// static
+ActivityTrackingService* ActivityTrackingServiceFactory::GetForProfile(
+    Profile* profile) {
+  return static_cast<ActivityTrackingService*>(
+      GetInstance()->GetServiceForBrowserContext(profile, true));
+}
+
+// static
+ActivityTrackingServiceFactory* ActivityTrackingServiceFactory::GetInstance() {
+  static base::NoDestructor<ActivityTrackingServiceFactory> instance;
+  return instance.get();
+}
+
+ActivityTrackingServiceFactory::ActivityTrackingServiceFactory()
+    : ProfileKeyedServiceFactory(
+          "ActivityTrackingService",
+          ProfileSelections::Builder()
+              .WithRegular(ProfileSelection::kOriginalOnly)
+              .WithGuest(ProfileSelection::kOriginalOnly)
+              .Build()) {}
+
+ActivityTrackingServiceFactory::~ActivityTrackingServiceFactory() = default;
+
+std::unique_ptr<KeyedService>
+ActivityTrackingServiceFactory::BuildServiceInstanceForBrowserContext(
+    content::BrowserContext* context) const {
+  Profile* profile = Profile::FromBrowserContext(context);
+  return std::make_unique<ActivityTrackingService>(profile);
+}
+
+bool ActivityTrackingServiceFactory::ServiceIsCreatedWithBrowserContext()
+    const {
+  // Create the service immediately when the profile is created
+  return true;
+}
+
+}  // namespace activity_tracking
+

--- a/src/chrome/browser/activity_tracking/activity_tracking_service_factory.h
+++ b/src/chrome/browser/activity_tracking/activity_tracking_service_factory.h
@@ -1,0 +1,44 @@
+// Copyright 2024 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef CHROME_BROWSER_ACTIVITY_TRACKING_ACTIVITY_TRACKING_SERVICE_FACTORY_H_
+#define CHROME_BROWSER_ACTIVITY_TRACKING_ACTIVITY_TRACKING_SERVICE_FACTORY_H_
+
+#include "base/no_destructor.h"
+#include "chrome/browser/profiles/profile_keyed_service_factory.h"
+
+class Profile;
+
+namespace activity_tracking {
+
+class ActivityTrackingService;
+
+// Factory to create ActivityTrackingService instances per profile.
+// This follows the standard Chromium KeyedService pattern.
+class ActivityTrackingServiceFactory : public ProfileKeyedServiceFactory {
+ public:
+  static ActivityTrackingService* GetForProfile(Profile* profile);
+  static ActivityTrackingServiceFactory* GetInstance();
+
+  ActivityTrackingServiceFactory(const ActivityTrackingServiceFactory&) =
+      delete;
+  ActivityTrackingServiceFactory& operator=(
+      const ActivityTrackingServiceFactory&) = delete;
+
+ private:
+  friend base::NoDestructor<ActivityTrackingServiceFactory>;
+
+  ActivityTrackingServiceFactory();
+  ~ActivityTrackingServiceFactory() override;
+
+  // BrowserContextKeyedServiceFactory:
+  std::unique_ptr<KeyedService> BuildServiceInstanceForBrowserContext(
+      content::BrowserContext* context) const override;
+  bool ServiceIsCreatedWithBrowserContext() const override;
+};
+
+}  // namespace activity_tracking
+
+#endif  // CHROME_BROWSER_ACTIVITY_TRACKING_ACTIVITY_TRACKING_SERVICE_FACTORY_H_
+

--- a/src/chrome/browser/activity_tracking/navigation_event_collector.cc
+++ b/src/chrome/browser/activity_tracking/navigation_event_collector.cc
@@ -1,0 +1,348 @@
+// Copyright 2024 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "chrome/browser/activity_tracking/navigation_event_collector.h"
+
+#include "base/json/json_writer.h"
+#include "base/logging.h"
+#include "base/strings/utf_string_conversions.h"
+#include "base/time/time.h"
+#include "chrome/browser/activity_tracking/privacy_filter.h"
+#include "chrome/browser/activity_tracking/splunk_observability_exporter.h"
+#include "content/public/browser/navigation_handle.h"
+#include "content/public/browser/page.h"
+#include "content/public/browser/web_contents.h"
+#include "net/base/net_errors.h"
+#include "net/http/http_response_headers.h"
+#include "net/http/http_util.h"
+#include "ui/base/page_transition_types.h"
+
+namespace activity_tracking {
+
+// NavigationEventData implementation
+NavigationEventCollector::NavigationEventData::NavigationEventData() = default;
+NavigationEventCollector::NavigationEventData::~NavigationEventData() = default;
+NavigationEventCollector::NavigationEventData::NavigationEventData(
+    const NavigationEventData&) = default;
+NavigationEventCollector::NavigationEventData& 
+NavigationEventCollector::NavigationEventData::operator=(
+    const NavigationEventData&) = default;
+
+NavigationEventCollector::NavigationEventCollector(
+    PrivacyFilter* privacy_filter)
+    : privacy_filter_(privacy_filter) {
+}
+
+NavigationEventCollector::~NavigationEventCollector() {
+  Shutdown();
+}
+
+void NavigationEventCollector::ObserveWebContents(
+    content::WebContents* web_contents) {
+  if (!web_contents) {
+    return;
+  }
+
+  // Check if already observing
+  if (observers_.find(web_contents) != observers_.end()) {
+    return;
+  }
+
+  auto observer =
+      std::make_unique<NavigationObserver>(web_contents, privacy_filter_);
+  observer->parent_collector_ = this;  // Set parent for event recording
+  observers_[web_contents] = std::move(observer);
+}
+
+void NavigationEventCollector::Shutdown() {
+  observers_.clear();
+}
+
+// NavigationObserver implementation
+
+NavigationEventCollector::NavigationObserver::NavigationObserver(
+    content::WebContents* web_contents,
+    PrivacyFilter* privacy_filter)
+    : content::WebContentsObserver(web_contents),
+      privacy_filter_(privacy_filter),
+      parent_collector_(nullptr) {}
+
+NavigationEventCollector::NavigationObserver::~NavigationObserver() = default;
+
+void NavigationEventCollector::NavigationObserver::DidStartNavigation(
+    content::NavigationHandle* navigation_handle) {
+  navigation_start_time_ = base::TimeTicks::Now();
+  LogNavigationStart(navigation_handle);
+}
+
+void NavigationEventCollector::NavigationObserver::DidRedirectNavigation(
+    content::NavigationHandle* navigation_handle) {
+  LogNavigationRedirect(navigation_handle);
+}
+
+void NavigationEventCollector::NavigationObserver::DidFinishNavigation(
+    content::NavigationHandle* navigation_handle) {
+  LogNavigationComplete(navigation_handle);
+}
+
+void NavigationEventCollector::NavigationObserver::PrimaryPageChanged(
+    content::Page& page) {
+  LogPrimaryPageChange(page);
+}
+
+void NavigationEventCollector::NavigationObserver::
+    DocumentOnLoadCompletedInPrimaryMainFrame() {
+  LogPageLoadComplete();
+}
+
+void NavigationEventCollector::NavigationObserver::DidStartLoading() {
+  page_load_start_time_ = base::TimeTicks::Now();
+}
+
+void NavigationEventCollector::NavigationObserver::DidStopLoading() {
+}
+
+void NavigationEventCollector::NavigationObserver::LoadProgressChanged(
+    double progress) {
+}
+
+void NavigationEventCollector::NavigationObserver::LogNavigationStart(
+    content::NavigationHandle* navigation_handle) {
+  std::string url =
+      privacy_filter_->FilterUrl(navigation_handle->GetURL().spec());
+  std::string referrer =
+      privacy_filter_->FilterUrl(navigation_handle->GetReferrer().url.spec());
+  
+  current_url_ = url;  // Store for later use
+
+  // Determine interaction type
+  std::string interaction_type;
+  ui::PageTransition transition = navigation_handle->GetPageTransition();
+  if (ui::PageTransitionCoreTypeIs(transition, ui::PAGE_TRANSITION_LINK)) {
+    interaction_type = "clicked";
+  } else if (ui::PageTransitionCoreTypeIs(transition, ui::PAGE_TRANSITION_TYPED)) {
+    interaction_type = "typed";
+  } else if (ui::PageTransitionCoreTypeIs(transition, ui::PAGE_TRANSITION_AUTO_BOOKMARK)) {
+    interaction_type = "bookmark";
+  } else if (ui::PageTransitionCoreTypeIs(transition, ui::PAGE_TRANSITION_RELOAD)) {
+    interaction_type = "reload";
+  } else {
+    interaction_type = "other";
+  }
+
+  // Record navigation start event
+  if (parent_collector_ && navigation_handle->IsInPrimaryMainFrame()) {
+    NavigationEventData event;
+    event.url = url;
+    event.title = "";  // Title not available yet
+    event.timestamp = net::HttpUtil::TimeFormatHTTP(base::Time::Now());
+    event.state = "started";
+    event.interaction_type = interaction_type;
+    event.duration_ms = 0;
+    parent_collector_->navigation_events_.push_back(event);
+  }
+}
+
+void NavigationEventCollector::NavigationObserver::LogNavigationRedirect(
+    content::NavigationHandle* navigation_handle) {
+}
+
+void NavigationEventCollector::NavigationObserver::LogNavigationComplete(
+    content::NavigationHandle* navigation_handle) {
+  std::string url =
+      privacy_filter_->FilterUrl(navigation_handle->GetURL().spec());
+
+  auto navigation_duration = base::TimeTicks::Now() - navigation_start_time_;
+
+  if (!navigation_handle->HasCommitted()) {
+    // Record failed navigation
+    if (parent_collector_ && navigation_handle->IsInPrimaryMainFrame()) {
+      NavigationEventData event;
+      event.url = url;
+      event.title = "";
+      event.timestamp = net::HttpUtil::TimeFormatHTTP(base::Time::Now());
+      event.state = "failed";
+      event.interaction_type = "navigation";
+      event.duration_ms = navigation_duration.InMilliseconds();
+      parent_collector_->navigation_events_.push_back(event);
+    }
+    return;
+  }
+
+  // Record completed navigation
+  if (parent_collector_ && navigation_handle->IsInPrimaryMainFrame()) {
+    NavigationEventData event;
+    event.url = url;
+    event.title = "";  // Title will be updated in page load complete
+    event.timestamp = net::HttpUtil::TimeFormatHTTP(base::Time::Now());
+    event.state = "completed";
+    event.interaction_type = "navigation";
+    event.duration_ms = navigation_duration.InMilliseconds();
+    parent_collector_->navigation_events_.push_back(event);
+  }
+}
+
+void NavigationEventCollector::NavigationObserver::LogPrimaryPageChange(
+    content::Page& page) {
+}
+
+void NavigationEventCollector::NavigationObserver::LogPageLoadComplete() {
+  auto* web_contents = this->web_contents();
+  if (!web_contents) {
+    return;
+  }
+
+  std::string url =
+      privacy_filter_->FilterUrl(web_contents->GetVisibleURL().spec());
+  std::string title = privacy_filter_->FilterTitle(
+      base::UTF16ToUTF8(web_contents->GetTitle()));
+
+  auto load_duration = base::TimeTicks::Now() - page_load_start_time_;
+
+  // Record final event with title
+  if (parent_collector_) {
+    NavigationEventData event;
+    event.url = url;
+    event.title = title;
+    event.timestamp = net::HttpUtil::TimeFormatHTTP(base::Time::Now());
+    event.state = "page_loaded";
+    event.interaction_type = "navigation";
+    event.duration_ms = load_duration.InMilliseconds();
+    parent_collector_->navigation_events_.push_back(event);
+    
+    // Log collected events every 10 navigations or on significant events
+    if (parent_collector_->navigation_events_.size() >= 10) {
+      parent_collector_->LogEventsAsOpenTelemetryJSON();
+    }
+  }
+}
+
+void NavigationEventCollector::NavigationObserver::RecordNavigationEvent(
+    const NavigationEventData& event) {
+  if (parent_collector_) {
+    parent_collector_->navigation_events_.push_back(event);
+  }
+}
+
+// NavigationEventCollector methods for OpenTelemetry
+
+std::vector<NavigationEventCollector::NavigationEventData>
+NavigationEventCollector::GetAndClearEvents() {
+  std::vector<NavigationEventData> events = std::move(navigation_events_);
+  navigation_events_.clear();
+  return events;
+}
+
+void NavigationEventCollector::LogEventsAsOpenTelemetryJSON() {
+  if (navigation_events_.empty()) {
+    return;
+  }
+
+  // Clear events after logging
+  navigation_events_.clear();
+}
+
+base::Value::Dict NavigationEventCollector::ConvertToOpenTelemetry() const {
+  base::Value::Dict root;
+  
+  // OpenTelemetry Log Data Model
+  root.Set("resourceLogs", base::Value::List());
+  base::Value::List* resource_logs = root.FindList("resourceLogs");
+  
+  base::Value::Dict resource_log;
+  
+  // Resource attributes
+  base::Value::Dict resource;
+  base::Value::Dict resource_attrs;
+  resource_attrs.Set("service.name", "chromium-browser");
+  resource_attrs.Set("service.version", "1.0.0");
+  resource.Set("attributes", std::move(resource_attrs));
+  resource_log.Set("resource", std::move(resource));
+  
+  // Scope logs
+  base::Value::List scope_logs;
+  base::Value::Dict scope_log;
+  
+  base::Value::Dict scope;
+  scope.Set("name", "navigation.tracker");
+  scope.Set("version", "1.0.0");
+  scope_log.Set("scope", std::move(scope));
+  
+  // Log records
+  base::Value::List log_records;
+  
+  for (const auto& event : navigation_events_) {
+    base::Value::Dict log_record;
+    
+    // Timestamp in Unix nano
+    log_record.Set("timeUnixNano", static_cast<double>(
+        base::Time::Now().InMillisecondsSinceUnixEpoch() * 1000000));
+    
+    // Severity
+    log_record.Set("severityNumber", 9);  // INFO
+    log_record.Set("severityText", "INFO");
+    
+    // Body
+    log_record.Set("body", base::Value::Dict()
+        .Set("stringValue", event.state));
+    
+    // Attributes - The actual navigation data
+    base::Value::Dict attributes;
+    attributes.Set("url", event.url);
+    attributes.Set("title", event.title);
+    attributes.Set("timestamp", event.timestamp);
+    attributes.Set("state", event.state);
+    attributes.Set("interaction_type", event.interaction_type);
+    attributes.Set("duration_ms", static_cast<double>(event.duration_ms));
+    
+    log_record.Set("attributes", std::move(attributes));
+    
+    log_records.Append(std::move(log_record));
+  }
+  
+  scope_log.Set("logRecords", std::move(log_records));
+  scope_logs.Append(std::move(scope_log));
+  resource_log.Set("scopeLogs", std::move(scope_logs));
+  
+  resource_logs->Append(std::move(resource_log));
+  
+  return root;
+}
+
+void NavigationEventCollector::SetExporter(
+    std::unique_ptr<SplunkObservabilityExporter> exporter) {
+  splunk_exporter_ = std::move(exporter);
+}
+
+void NavigationEventCollector::ExportToSplunk() {
+  if (!splunk_exporter_ || navigation_events_.empty()) {
+    return;
+  }
+  
+  // Convert to OpenTelemetry format
+  base::Value::Dict otel_json = ConvertToOpenTelemetry();
+  
+  // Export both as events and metrics
+  splunk_exporter_->ExportEvents(
+      otel_json,
+      base::BindOnce([](SplunkObservabilityExporter::ExportResult result) {
+        if (result != SplunkObservabilityExporter::ExportResult::SUCCESS) {
+          LOG(ERROR) << "[NavigationCollector] Events export failed";
+        }
+      }));
+  
+  splunk_exporter_->ExportMetrics(
+      otel_json,
+      base::BindOnce([](SplunkObservabilityExporter::ExportResult result) {
+        if (result != SplunkObservabilityExporter::ExportResult::SUCCESS) {
+          LOG(ERROR) << "[NavigationCollector] Metrics export failed";
+        }
+      }));
+  
+  // Clear events after export
+  navigation_events_.clear();
+}
+
+}  // namespace activity_tracking
+

--- a/src/chrome/browser/activity_tracking/navigation_event_collector.h
+++ b/src/chrome/browser/activity_tracking/navigation_event_collector.h
@@ -1,0 +1,139 @@
+// Copyright 2024 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef CHROME_BROWSER_ACTIVITY_TRACKING_NAVIGATION_EVENT_COLLECTOR_H_
+#define CHROME_BROWSER_ACTIVITY_TRACKING_NAVIGATION_EVENT_COLLECTOR_H_
+
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "base/memory/raw_ptr.h"
+#include "base/scoped_observation.h"
+#include "base/time/time.h"
+#include "base/values.h"
+#include "content/public/browser/web_contents_observer.h"
+
+namespace content {
+class NavigationHandle;
+class WebContents;
+class Page;
+}  // namespace content
+
+namespace activity_tracking {
+
+class PrivacyFilter;
+class SplunkObservabilityExporter;
+
+// NavigationEventCollector observes navigation events across all WebContents
+// and logs detailed information about each navigation.
+//
+// This class creates per-WebContents observers that track:
+// - Navigation start (URL, referrer, initiator)
+// - Navigation redirects
+// - Navigation completion (success/failure, HTTP status, errors)
+// - Page load completion
+// - Primary page changes
+class NavigationEventCollector {
+ public:
+  // Structure to store navigation event data
+  struct NavigationEventData {
+    NavigationEventData();
+    ~NavigationEventData();
+    NavigationEventData(const NavigationEventData&);
+    NavigationEventData& operator=(const NavigationEventData&);
+    
+    std::string url;
+    std::string title;
+    std::string timestamp;  // ISO 8601 format
+    std::string state;      // "started", "completed", "failed"
+    std::string interaction_type;  // "clicked", "typed", "redirect"
+    int64_t duration_ms = 0;
+  };
+
+  explicit NavigationEventCollector(PrivacyFilter* privacy_filter);
+  ~NavigationEventCollector();
+
+  NavigationEventCollector(const NavigationEventCollector&) = delete;
+  NavigationEventCollector& operator=(const NavigationEventCollector&) = delete;
+
+  // Start observing navigation events for a WebContents
+  void ObserveWebContents(content::WebContents* web_contents);
+
+  // Stop observing and clean up
+  void Shutdown();
+
+  // Get collected events and clear the buffer
+  std::vector<NavigationEventData> GetAndClearEvents();
+  
+  // Convert events to OpenTelemetry JSON format and log
+  void LogEventsAsOpenTelemetryJSON();
+  
+  // Set Splunk Observability exporter
+  void SetExporter(std::unique_ptr<SplunkObservabilityExporter> exporter);
+  
+  // Export collected events to Splunk Observability Cloud
+  void ExportToSplunk();
+
+ private:
+  // Per-WebContents observer that tracks navigation events
+  class NavigationObserver : public content::WebContentsObserver {
+   public:
+    NavigationObserver(content::WebContents* web_contents,
+                       PrivacyFilter* privacy_filter);
+    ~NavigationObserver() override;
+
+    // WebContentsObserver implementation:
+    void DidStartNavigation(
+        content::NavigationHandle* navigation_handle) override;
+    void DidRedirectNavigation(
+        content::NavigationHandle* navigation_handle) override;
+    void DidFinishNavigation(
+        content::NavigationHandle* navigation_handle) override;
+    void PrimaryPageChanged(content::Page& page) override;
+    void DocumentOnLoadCompletedInPrimaryMainFrame() override;
+    void DidStartLoading() override;
+    void DidStopLoading() override;
+    void LoadProgressChanged(double progress) override;
+
+   private:
+    void LogNavigationStart(content::NavigationHandle* navigation_handle);
+    void LogNavigationRedirect(content::NavigationHandle* navigation_handle);
+    void LogNavigationComplete(content::NavigationHandle* navigation_handle);
+    void LogPrimaryPageChange(content::Page& page);
+    void LogPageLoadComplete();
+    
+    void RecordNavigationEvent(const NavigationEventData& event);
+
+    raw_ptr<PrivacyFilter> privacy_filter_;
+    base::TimeTicks navigation_start_time_;
+    base::TimeTicks page_load_start_time_;
+    std::string current_url_;
+    std::string current_title_;
+    
+   public:
+    raw_ptr<NavigationEventCollector> parent_collector_;
+  };
+
+  // Convert events to OpenTelemetry format
+  base::Value::Dict ConvertToOpenTelemetry() const;
+
+  raw_ptr<PrivacyFilter> privacy_filter_;
+
+  // Map of WebContents to their observers
+  std::map<raw_ptr<content::WebContents>, std::unique_ptr<NavigationObserver>>
+      observers_;
+  
+  // Buffer for collected navigation events
+  std::vector<NavigationEventData> navigation_events_;
+  
+  // Splunk Observability Cloud exporter
+  std::unique_ptr<SplunkObservabilityExporter> splunk_exporter_;
+};
+
+}  // namespace activity_tracking
+
+#endif  // CHROME_BROWSER_ACTIVITY_TRACKING_NAVIGATION_EVENT_COLLECTOR_H_
+

--- a/src/chrome/browser/activity_tracking/privacy_filter.cc
+++ b/src/chrome/browser/activity_tracking/privacy_filter.cc
@@ -1,0 +1,137 @@
+// Copyright 2024 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "chrome/browser/activity_tracking/privacy_filter.h"
+
+#include "base/strings/string_split.h"
+#include "base/strings/string_util.h"
+#include "chrome/browser/profiles/profile.h"
+#include "url/gurl.h"
+
+namespace activity_tracking {
+
+namespace {
+
+// Sensitive query parameters to remove from URLs
+const char* kSensitiveParams[] = {
+    "token",     "access_token", "api_key",  "apikey",   "auth",
+    "password",  "pwd",          "secret",   "session",  "sid",
+    "sessionid", "key",          "api_token", "private_key"};
+
+}  // namespace
+
+PrivacyFilter::PrivacyFilter(Profile* profile) : profile_(profile) {}
+
+PrivacyFilter::~PrivacyFilter() = default;
+
+std::string PrivacyFilter::FilterUrl(const std::string& url) const {
+  if (!IsTrackingAllowed()) {
+    return "[tracking disabled]";
+  }
+
+  if (IsIncognitoMode()) {
+    return RedactUrl(url);
+  }
+
+  // For regular profiles, remove sensitive query parameters
+  return RemoveSensitiveParams(url);
+}
+
+std::string PrivacyFilter::FilterTitle(const std::string& title) const {
+  if (!IsTrackingAllowed()) {
+    return "[tracking disabled]";
+  }
+
+  if (IsIncognitoMode()) {
+    return "[incognito]";
+  }
+
+  // For regular profiles, return the title as-is
+  // In the future, could add PII detection and filtering here
+  return title;
+}
+
+bool PrivacyFilter::IsTrackingAllowed() const {
+  if (!profile_) {
+    return false;
+  }
+
+  // Don't track in incognito mode by default
+  // Enterprise deployments can override this policy
+  if (IsIncognitoMode()) {
+    // TODO: Check enterprise policy to allow incognito tracking if configured
+    return false;
+  }
+
+  return true;
+}
+
+bool PrivacyFilter::IsIncognitoMode() const {
+  return profile_ && profile_->IsOffTheRecord();
+}
+
+std::string PrivacyFilter::RemoveSensitiveParams(const std::string& url) const {
+  GURL gurl(url);
+  if (!gurl.is_valid() || !gurl.has_query()) {
+    return url;
+  }
+
+  std::string query = gurl.query();
+  bool has_sensitive_param = false;
+
+  for (const char* param : kSensitiveParams) {
+    if (query.find(param) != std::string::npos) {
+      has_sensitive_param = true;
+      break;
+    }
+  }
+
+  if (!has_sensitive_param) {
+    return url;
+  }
+
+  // Reconstruct URL without sensitive parameters
+  GURL::Replacements replacements;
+  replacements.ClearQuery();
+
+  // Parse and filter query parameters
+  std::vector<std::string> filtered_params;
+  std::vector<std::string> params = base::SplitString(
+      query, "&", base::TRIM_WHITESPACE, base::SPLIT_WANT_NONEMPTY);
+
+  for (const auto& param : params) {
+    bool is_sensitive = false;
+    for (const char* sensitive_param : kSensitiveParams) {
+      if (base::StartsWith(param, std::string(sensitive_param) + "=",
+                           base::CompareCase::INSENSITIVE_ASCII)) {
+        is_sensitive = true;
+        break;
+      }
+    }
+
+    if (!is_sensitive) {
+      filtered_params.push_back(param);
+    }
+  }
+
+  if (!filtered_params.empty()) {
+    std::string filtered_query = base::JoinString(filtered_params, "&");
+    replacements.SetQueryStr(filtered_query);
+  }
+
+  return gurl.ReplaceComponents(replacements).spec();
+}
+
+std::string PrivacyFilter::RedactUrl(const std::string& url) const {
+  GURL gurl(url);
+  if (!gurl.is_valid()) {
+    return "[invalid-url]";
+  }
+
+  // For incognito, only show scheme and host
+  return gurl.scheme() + "://" + gurl.host() + "/[incognito]";
+}
+
+}  // namespace activity_tracking
+

--- a/src/chrome/browser/activity_tracking/privacy_filter.h
+++ b/src/chrome/browser/activity_tracking/privacy_filter.h
@@ -1,0 +1,59 @@
+// Copyright 2024 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef CHROME_BROWSER_ACTIVITY_TRACKING_PRIVACY_FILTER_H_
+#define CHROME_BROWSER_ACTIVITY_TRACKING_PRIVACY_FILTER_H_
+
+#include <string>
+
+#include "base/memory/raw_ptr.h"
+
+class Profile;
+
+namespace activity_tracking {
+
+// PrivacyFilter handles filtering and sanitization of sensitive data
+// before it is logged or exported.
+//
+// This class provides methods to:
+// - Filter URLs (respect incognito mode, remove sensitive params)
+// - Filter page titles (sanitize PII)
+// - Check if logging is allowed for the current profile
+// - Apply enterprise policies for data collection
+//
+// In incognito mode, all URLs and titles are redacted to protect privacy.
+class PrivacyFilter {
+ public:
+  explicit PrivacyFilter(Profile* profile);
+  ~PrivacyFilter();
+
+  PrivacyFilter(const PrivacyFilter&) = delete;
+  PrivacyFilter& operator=(const PrivacyFilter&) = delete;
+
+  // Filter a URL - returns filtered/redacted URL based on privacy settings
+  std::string FilterUrl(const std::string& url) const;
+
+  // Filter a page title - returns filtered/redacted title
+  std::string FilterTitle(const std::string& title) const;
+
+  // Check if activity tracking is allowed for this profile
+  bool IsTrackingAllowed() const;
+
+  // Check if the current profile is in incognito/private mode
+  bool IsIncognitoMode() const;
+
+ private:
+  // Remove sensitive query parameters from URL
+  std::string RemoveSensitiveParams(const std::string& url) const;
+
+  // Redact the URL for privacy (used in incognito)
+  std::string RedactUrl(const std::string& url) const;
+
+  raw_ptr<Profile> profile_;
+};
+
+}  // namespace activity_tracking
+
+#endif  // CHROME_BROWSER_ACTIVITY_TRACKING_PRIVACY_FILTER_H_
+

--- a/src/chrome/browser/activity_tracking/splunk_observability_exporter.cc
+++ b/src/chrome/browser/activity_tracking/splunk_observability_exporter.cc
@@ -1,0 +1,397 @@
+// Copyright 2024 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "chrome/browser/activity_tracking/splunk_observability_exporter.h"
+
+#include "base/json/json_writer.h"
+#include "base/logging.h"
+#include "base/strings/stringprintf.h"
+#include "base/time/time.h"
+#include "net/base/load_flags.h"
+#include "net/http/http_status_code.h"
+#include "net/traffic_annotation/network_traffic_annotation.h"
+#include "services/network/public/cpp/resource_request.h"
+#include "services/network/public/cpp/simple_url_loader.h"
+#include "services/network/public/mojom/url_response_head.mojom.h"
+#include "url/gurl.h"
+
+namespace activity_tracking {
+
+namespace {
+
+// Network traffic annotation for SignalFx exports
+const net::NetworkTrafficAnnotationTag kSignalFxTrafficAnnotation =
+    net::DefineNetworkTrafficAnnotation("splunk_observability_export", R"(
+        semantics {
+          sender: "Activity Tracking Service"
+          description:
+            "Exports browser navigation telemetry data to Splunk Observability "
+            "Cloud (SignalFx) for analytics, monitoring, and observability."
+          trigger:
+            "Triggered when navigation events are collected and ready to export."
+          data:
+            "Navigation URLs (filtered for privacy), page titles, timestamps, "
+            "navigation states, and interaction types."
+          destination: OTHER
+          destination_other: "Splunk Observability Cloud SignalFx"
+        }
+        policy {
+          cookies_allowed: NO
+          setting:
+            "This feature can be controlled via enterprise policy or "
+            "command-line flags."
+          policy_exception_justification:
+            "Not implemented yet. This is for development and monitoring."
+        })");
+
+}  // namespace
+
+SplunkObservabilityExporter::Config::Config() = default;
+SplunkObservabilityExporter::Config::~Config() = default;
+SplunkObservabilityExporter::Config::Config(const Config&) = default;
+SplunkObservabilityExporter::Config& SplunkObservabilityExporter::Config::operator=(
+    const Config&) = default;
+
+SplunkObservabilityExporter::SplunkObservabilityExporter(
+    scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
+    const Config& config)
+    : url_loader_factory_(std::move(url_loader_factory)),
+      config_(config) {
+}
+
+SplunkObservabilityExporter::~SplunkObservabilityExporter() = default;
+
+void SplunkObservabilityExporter::ExportEvents(
+    const base::Value::Dict& otel_json,
+    ExportCallback callback) {
+  
+  if (!config_.enable_events) {
+    std::move(callback).Run(ExportResult::SUCCESS);
+    return;
+  }
+
+  base::Value::List signalfx_events = ConvertOTelToSignalFxEvents(otel_json);
+  
+  if (signalfx_events.empty()) {
+    std::move(callback).Run(ExportResult::SUCCESS);
+    return;
+  }
+
+  // Build event endpoint
+  std::string event_endpoint = config_.ingest_endpoint;
+  if (event_endpoint.find("/v2/") == std::string::npos) {
+    // Append /v2/event if not present
+    if (event_endpoint.back() != '/') {
+      event_endpoint += '/';
+    }
+    event_endpoint += "v2/event";
+  }
+
+  SendToSignalFx(event_endpoint, signalfx_events, std::move(callback));
+}
+
+void SplunkObservabilityExporter::ExportMetrics(
+    const base::Value::Dict& otel_json,
+    ExportCallback callback) {
+  
+  if (!config_.enable_metrics) {
+    std::move(callback).Run(ExportResult::SUCCESS);
+    return;
+  }
+
+  base::Value::List signalfx_datapoints = 
+      ConvertOTelToSignalFxDatapoints(otel_json);
+  
+  if (signalfx_datapoints.empty()) {
+    std::move(callback).Run(ExportResult::SUCCESS);
+    return;
+  }
+
+  // Build datapoint endpoint
+  std::string datapoint_endpoint = config_.ingest_endpoint;
+  if (datapoint_endpoint.find("/v2/") == std::string::npos) {
+    // Append /v2/datapoint if not present
+    if (datapoint_endpoint.back() != '/') {
+      datapoint_endpoint += '/';
+    }
+    datapoint_endpoint += "v2/datapoint";
+  }
+
+  SendToSignalFx(datapoint_endpoint, signalfx_datapoints, std::move(callback));
+}
+
+base::Value::List SplunkObservabilityExporter::ConvertOTelToSignalFxEvents(
+    const base::Value::Dict& otel_json) {
+  
+  base::Value::List signalfx_events;
+
+  // Extract log records from OpenTelemetry format
+  const base::Value::List* resource_logs = otel_json.FindList("resourceLogs");
+  if (!resource_logs) {
+    return signalfx_events;
+  }
+
+  for (const auto& resource_log : *resource_logs) {
+    const base::Value::Dict* resource_log_dict = resource_log.GetIfDict();
+    if (!resource_log_dict) continue;
+
+    const base::Value::List* scope_logs = 
+        resource_log_dict->FindList("scopeLogs");
+    if (!scope_logs) continue;
+
+    for (const auto& scope_log : *scope_logs) {
+      const base::Value::Dict* scope_log_dict = scope_log.GetIfDict();
+      if (!scope_log_dict) continue;
+
+      const base::Value::List* log_records = 
+          scope_log_dict->FindList("logRecords");
+      if (!log_records) continue;
+
+      for (const auto& log_record : *log_records) {
+        const base::Value::Dict* log_record_dict = log_record.GetIfDict();
+        if (!log_record_dict) continue;
+
+        // Convert to SignalFx Event format
+        base::Value::Dict signalfx_event;
+
+        // Extract attributes
+        const base::Value::Dict* attributes = 
+            log_record_dict->FindDict("attributes");
+        if (!attributes) continue;
+
+        // Required fields for SignalFx events
+        const std::string* url = attributes->FindString("url");
+        const std::string* state = attributes->FindString("state");
+        const std::string* timestamp = attributes->FindString("timestamp");
+        const std::string* interaction_type = 
+            attributes->FindString("interaction_type");
+
+        if (!url || !state) continue;
+
+        // Event category (required)
+        signalfx_event.Set("category", "USER_DEFINED");
+
+        // Event type (required) - use state as event type
+        signalfx_event.Set("eventType", *state);
+
+        // Timestamp (milliseconds since epoch)
+        // TODO: Parse timestamp string; for now use current time
+        int64_t ts = base::Time::Now().InMillisecondsSinceUnixEpoch();
+        signalfx_event.Set("timestamp", static_cast<double>(ts));
+
+        // Properties (dimensions and custom properties)
+        base::Value::Dict properties;
+        properties.Set("url", *url);
+        properties.Set("state", *state);
+        
+        if (interaction_type) {
+          properties.Set("interaction_type", *interaction_type);
+        }
+
+        const std::string* title = attributes->FindString("title");
+        if (title) {
+          properties.Set("title", *title);
+        }
+
+        std::optional<double> duration_ms = attributes->FindDouble("duration_ms");
+        if (duration_ms) {
+          properties.Set("duration_ms", *duration_ms);
+        }
+
+        // Add common dimensions
+        properties.Set("service", "chromium-browser");
+        properties.Set("component", "navigation-tracker");
+        properties.Set("platform", "android");
+
+        signalfx_event.Set("properties", std::move(properties));
+
+        signalfx_events.Append(std::move(signalfx_event));
+      }
+    }
+  }
+
+  return signalfx_events;
+}
+
+base::Value::List SplunkObservabilityExporter::ConvertOTelToSignalFxDatapoints(
+    const base::Value::Dict& otel_json) {
+  
+  base::Value::List signalfx_datapoints;
+
+  // Extract log records from OpenTelemetry format
+  const base::Value::List* resource_logs = otel_json.FindList("resourceLogs");
+  if (!resource_logs) {
+    return signalfx_datapoints;
+  }
+
+  for (const auto& resource_log : *resource_logs) {
+    const base::Value::Dict* resource_log_dict = resource_log.GetIfDict();
+    if (!resource_log_dict) continue;
+
+    const base::Value::List* scope_logs = 
+        resource_log_dict->FindList("scopeLogs");
+    if (!scope_logs) continue;
+
+    for (const auto& scope_log : *scope_logs) {
+      const base::Value::Dict* scope_log_dict = scope_log.GetIfDict();
+      if (!scope_log_dict) continue;
+
+      const base::Value::List* log_records = 
+          scope_log_dict->FindList("logRecords");
+      if (!log_records) continue;
+
+      for (const auto& log_record : *log_records) {
+        const base::Value::Dict* log_record_dict = log_record.GetIfDict();
+        if (!log_record_dict) continue;
+
+        const base::Value::Dict* attributes = 
+            log_record_dict->FindDict("attributes");
+        if (!attributes) continue;
+
+        // Create a gauge metric for navigation duration
+        std::optional<double> duration_ms = attributes->FindDouble("duration_ms");
+        if (!duration_ms || *duration_ms <= 0) continue;
+
+        base::Value::Dict datapoint;
+
+        // Metric name (required)
+        datapoint.Set("metric", "navigation.duration");
+
+        // Value (required)
+        base::Value::Dict value;
+        value.Set("doubleValue", *duration_ms);
+        datapoint.Set("value", std::move(value));
+
+        // Metric type (required): GAUGE, COUNTER, or CUMULATIVE_COUNTER
+        datapoint.Set("metricType", "GAUGE");
+
+        // Timestamp (milliseconds since epoch)
+        // TODO: Parse timestamp string; for now use current time
+        int64_t ts = base::Time::Now().InMillisecondsSinceUnixEpoch();
+        datapoint.Set("timestamp", static_cast<double>(ts));
+
+        // Dimensions (tags)
+        base::Value::List dimensions;
+
+        const std::string* state = attributes->FindString("state");
+        if (state) {
+          base::Value::Dict dim;
+          dim.Set("key", "state");
+          dim.Set("value", *state);
+          dimensions.Append(std::move(dim));
+        }
+
+        const std::string* interaction_type = 
+            attributes->FindString("interaction_type");
+        if (interaction_type) {
+          base::Value::Dict dim;
+          dim.Set("key", "interaction_type");
+          dim.Set("value", *interaction_type);
+          dimensions.Append(std::move(dim));
+        }
+
+        // Add common dimensions
+        base::Value::Dict service_dim;
+        service_dim.Set("key", "service");
+        service_dim.Set("value", "chromium-browser");
+        dimensions.Append(std::move(service_dim));
+
+        base::Value::Dict platform_dim;
+        platform_dim.Set("key", "platform");
+        platform_dim.Set("value", "android");
+        dimensions.Append(std::move(platform_dim));
+
+        datapoint.Set("dimensions", std::move(dimensions));
+
+        signalfx_datapoints.Append(std::move(datapoint));
+      }
+    }
+  }
+
+  return signalfx_datapoints;
+}
+
+void SplunkObservabilityExporter::SendToSignalFx(
+    const std::string& endpoint,
+    const base::Value::List& payload,
+    ExportCallback callback) {
+  
+  // Convert payload to JSON string
+  std::string json_payload;
+  if (!base::JSONWriter::Write(payload, &json_payload)) {
+    LOG(ERROR) << "[SplunkExporter] Failed to serialize JSON payload";
+    std::move(callback).Run(ExportResult::FAILURE);
+    return;
+  }
+
+  // Create resource request
+  auto resource_request = std::make_unique<network::ResourceRequest>();
+  resource_request->url = GURL(endpoint);
+  resource_request->method = "POST";
+  resource_request->load_flags = 
+      net::LOAD_BYPASS_CACHE | net::LOAD_DISABLE_CACHE;
+  resource_request->credentials_mode = network::mojom::CredentialsMode::kOmit;
+
+  // Set SignalFx headers (X-SF-TOKEN for ingest API)
+  resource_request->headers.SetHeader("Content-Type", "application/json");
+  resource_request->headers.SetHeader("X-SF-TOKEN", config_.access_token);
+  resource_request->headers.SetHeader("User-Agent", "Chromium-Activity-Tracker/1.0");
+
+  // Create URL loader
+  auto url_loader = network::SimpleURLLoader::Create(
+      std::move(resource_request), kSignalFxTrafficAnnotation);
+
+  // Attach payload
+  url_loader->AttachStringForUpload(json_payload, "application/json");
+
+  // Set timeout
+  url_loader->SetTimeoutDuration(base::Milliseconds(config_.timeout_ms));
+
+  // Allow retry on network change
+  url_loader->SetRetryOptions(
+      1, network::SimpleURLLoader::RETRY_ON_NETWORK_CHANGE);
+
+  // Keep loader alive
+  auto* url_loader_ptr = url_loader.get();
+  
+  // Start request
+  url_loader_ptr->DownloadToString(
+      url_loader_factory_.get(),
+      base::BindOnce(&SplunkObservabilityExporter::OnExportComplete,
+                     base::Unretained(this),
+                     std::move(url_loader),
+                     std::move(callback)),
+      1024 * 1024);  // 1MB max response
+}
+
+void SplunkObservabilityExporter::OnExportComplete(
+    std::unique_ptr<network::SimpleURLLoader> loader,
+    ExportCallback callback,
+    std::unique_ptr<std::string> response_body) {
+  
+  int response_code = -1;
+  if (loader->ResponseInfo() && loader->ResponseInfo()->headers) {
+    response_code = loader->ResponseInfo()->headers->response_code();
+  }
+
+  int net_error = loader->NetError();
+
+  ExportResult result;
+
+  if (net_error == net::OK && response_code >= 200 && response_code < 300) {
+    result = ExportResult::SUCCESS;
+  } else if (net_error == net::ERR_TIMED_OUT) {
+    LOG(ERROR) << "[SplunkExporter] Export timeout";
+    result = ExportResult::TIMEOUT;
+  } else {
+    LOG(ERROR) << "[SplunkExporter] Export failed - HTTP " << response_code 
+               << ", Net error " << net_error;
+    result = ExportResult::FAILURE;
+  }
+
+  std::move(callback).Run(result);
+}
+
+}  // namespace activity_tracking
+

--- a/src/chrome/browser/activity_tracking/splunk_observability_exporter.h
+++ b/src/chrome/browser/activity_tracking/splunk_observability_exporter.h
@@ -1,0 +1,94 @@
+// Copyright 2024 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef CHROME_BROWSER_ACTIVITY_TRACKING_SPLUNK_OBSERVABILITY_EXPORTER_H_
+#define CHROME_BROWSER_ACTIVITY_TRACKING_SPLUNK_OBSERVABILITY_EXPORTER_H_
+
+#include <memory>
+#include <string>
+
+#include "base/functional/callback.h"
+#include "base/memory/raw_ptr.h"
+#include "base/memory/scoped_refptr.h"
+#include "base/values.h"
+#include "services/network/public/cpp/shared_url_loader_factory.h"
+#include "services/network/public/cpp/simple_url_loader.h"
+
+namespace activity_tracking {
+
+// Exports navigation telemetry to Splunk Observability Cloud (SignalFx)
+// Uses Chromium's network stack to send data to the SignalFx ingest API
+class SplunkObservabilityExporter {
+ public:
+  enum class ExportResult {
+    SUCCESS,
+    FAILURE,
+    TIMEOUT,
+    NETWORK_ERROR,
+  };
+
+  using ExportCallback = base::OnceCallback<void(ExportResult)>;
+
+  // Configuration for Splunk Observability Cloud
+  struct Config {
+    Config();
+    ~Config();
+    Config(const Config&);
+    Config& operator=(const Config&);
+    
+    std::string realm;                // e.g., "sg0" for Singapore
+    std::string access_token;         // SignalFx access token (sent as X-SF-TOKEN header)
+    std::string ingest_endpoint;      // Ingest endpoint: https://ingest.<realm>.signalfx.com
+    int timeout_ms = 30000;           // 30 seconds default
+    bool enable_metrics = true;       // Send to /v2/datapoint
+    bool enable_events = true;        // Send to /v2/event
+    bool enable_traces = false;       // Send to /v2/trace (not implemented yet)
+  };
+
+  SplunkObservabilityExporter(
+      scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
+      const Config& config);
+  ~SplunkObservabilityExporter();
+
+  // Export OpenTelemetry JSON logs as SignalFx events
+  void ExportEvents(const base::Value::Dict& otel_json, 
+                    ExportCallback callback);
+
+  // Export OpenTelemetry JSON logs as SignalFx metrics (datapoints)
+  void ExportMetrics(const base::Value::Dict& otel_json,
+                     ExportCallback callback);
+
+  // Get configuration
+  const Config& config() const { return config_; }
+
+ private:
+  // Convert OpenTelemetry log format to SignalFx event format
+  base::Value::List ConvertOTelToSignalFxEvents(
+      const base::Value::Dict& otel_json);
+
+  // Convert OpenTelemetry log format to SignalFx datapoint format
+  base::Value::List ConvertOTelToSignalFxDatapoints(
+      const base::Value::Dict& otel_json);
+
+  // Send data to SignalFx API
+  void SendToSignalFx(const std::string& endpoint,
+                      const base::Value::List& payload,
+                      ExportCallback callback);
+
+  // Handle network response
+  void OnExportComplete(std::unique_ptr<network::SimpleURLLoader> loader,
+                        ExportCallback callback,
+                        std::unique_ptr<std::string> response_body);
+
+  scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory_;
+  Config config_;
+
+  // Track active requests
+  std::vector<std::unique_ptr<network::SimpleURLLoader>> active_loaders_;
+};
+
+}  // namespace activity_tracking
+
+#endif  // CHROME_BROWSER_ACTIVITY_TRACKING_SPLUNK_OBSERVABILITY_EXPORTER_H_
+

--- a/src/chrome/browser/activity_tracking/tab_event_collector.cc
+++ b/src/chrome/browser/activity_tracking/tab_event_collector.cc
@@ -1,0 +1,472 @@
+// Copyright 2024 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "chrome/browser/activity_tracking/tab_event_collector.h"
+
+#include "base/logging.h"
+#include "base/strings/string_number_conversions.h"
+#include "base/strings/utf_string_conversions.h"
+#include "build/build_config.h"
+#include "chrome/browser/activity_tracking/navigation_event_collector.h"
+#include "chrome/browser/activity_tracking/privacy_filter.h"
+#include "content/public/browser/web_contents.h"
+
+#if !BUILDFLAG(IS_ANDROID)
+#include "chrome/browser/ui/tabs/tab_strip_model.h"
+#else
+#include "chrome/browser/android/tab_android.h"
+#include "chrome/browser/ui/android/tab_model/tab_model.h"
+#endif
+
+namespace activity_tracking {
+
+TabEventCollector::TabEventCollector(PrivacyFilter* privacy_filter,
+                                     NavigationEventCollector* navigation_collector)
+    : privacy_filter_(privacy_filter),
+      navigation_collector_(navigation_collector) {
+  LOG(ERROR) << "[TabCollector] Initialized";
+}
+
+TabEventCollector::~TabEventCollector() {
+  Shutdown();
+}
+
+#if !BUILDFLAG(IS_ANDROID)
+// Desktop implementation
+void TabEventCollector::ObserveTabStripModel(TabStripModel* tab_strip_model) {
+  if (!tab_strip_model) {
+    return;
+  }
+
+  // Check if already observing
+  if (observers_.find(tab_strip_model) != observers_.end()) {
+    return;
+  }
+
+  auto observer =
+      std::make_unique<TabStripObserver>(tab_strip_model, privacy_filter_);
+  observers_[tab_strip_model] = std::move(observer);
+
+  LOG(ERROR) << "[TabCollector] Now observing TabStripModel with "
+            << tab_strip_model->count() << " tabs";
+}
+
+void TabEventCollector::StopObservingTabStripModel(
+    TabStripModel* tab_strip_model) {
+  auto it = observers_.find(tab_strip_model);
+  if (it != observers_.end()) {
+    LOG(ERROR) << "[TabCollector] Stopped observing TabStripModel";
+    observers_.erase(it);
+  }
+}
+
+void TabEventCollector::Shutdown() {
+  LOG(ERROR) << "[TabCollector] Shutting down";
+  observers_.clear();
+}
+
+// Desktop TabStripObserver implementation
+
+TabEventCollector::TabStripObserver::TabStripObserver(
+    TabStripModel* tab_strip_model,
+    PrivacyFilter* privacy_filter)
+    : tab_strip_model_(tab_strip_model), privacy_filter_(privacy_filter) {
+  tab_strip_model_->AddObserver(this);
+}
+
+TabEventCollector::TabStripObserver::~TabStripObserver() {
+  if (tab_strip_model_) {
+    tab_strip_model_->RemoveObserver(this);
+  }
+}
+
+void TabEventCollector::TabStripObserver::OnTabStripModelChanged(
+    TabStripModel* tab_strip_model,
+    const TabStripModelChange& change,
+    const TabStripSelectionChange& selection) {
+  // Log tab structure changes
+  switch (change.type()) {
+    case TabStripModelChange::kInserted:
+      LogTabInserted(change.GetInsert());
+      break;
+    case TabStripModelChange::kRemoved:
+      LogTabRemoved(change.GetRemove());
+      break;
+    case TabStripModelChange::kMoved:
+      LogTabMoved(change.GetMove());
+      break;
+    case TabStripModelChange::kReplaced:
+      LogTabReplaced(change.GetReplace());
+      break;
+    case TabStripModelChange::kSelectionOnly:
+      // Handled by selection change below
+      break;
+  }
+
+  // Log selection/activation changes
+  if (selection.active_tab_changed()) {
+    LogTabActivation(selection);
+  }
+}
+
+void TabEventCollector::TabStripObserver::TabChangedAt(
+    content::WebContents* contents,
+    int index,
+    TabChangeType change_type) {
+  LogTabChanged(contents, index, change_type);
+}
+
+void TabEventCollector::TabStripObserver::TabPinnedStateChanged(
+    TabStripModel* tab_strip_model,
+    content::WebContents* contents,
+    int index) {
+  bool is_pinned = tab_strip_model->IsTabPinned(index);
+  LogTabPinnedStateChanged(contents, index, is_pinned);
+}
+
+void TabEventCollector::TabStripObserver::TabGroupedStateChanged(
+    std::optional<tab_groups::TabGroupId> group,
+    content::WebContents* contents,
+    int index) {
+  std::string url =
+      privacy_filter_->FilterUrl(contents->GetVisibleURL().spec());
+
+  if (group.has_value()) {
+    LOG(INFO) << "[Tab] TAB_GROUPED"
+              << " | Index: " << index << " | URL: " << url
+              << " | Group ID: " << group.value().ToString();
+  } else {
+    LOG(INFO) << "[Tab] TAB_UNGROUPED"
+              << " | Index: " << index << " | URL: " << url;
+  }
+}
+
+void TabEventCollector::TabStripObserver::OnTabGroupChanged(
+    const TabGroupChange& change) {
+  LogTabGroupChange(change);
+}
+
+void TabEventCollector::TabStripObserver::LogTabInserted(
+    const TabStripModelChange::Insert* insert) {
+  for (const auto& content : insert->contents) {
+    std::string url =
+        privacy_filter_->FilterUrl(content.contents->GetVisibleURL().spec());
+
+    LOG(INFO) << "[Tab] TAB_INSERTED"
+              << " | Index: " << content.index << " | URL: " << url
+              << " | Total Tabs: " << tab_strip_model_->count();
+  }
+}
+
+void TabEventCollector::TabStripObserver::LogTabRemoved(
+    const TabStripModelChange::Remove* remove) {
+  for (const auto& removed_tab : remove->contents) {
+    std::string url = privacy_filter_->FilterUrl(
+        removed_tab.contents->GetVisibleURL().spec());
+
+    std::string reason_str;
+    switch (removed_tab.remove_reason) {
+      case TabStripModelChange::RemoveReason::kDeleted:
+        reason_str = "Deleted";
+        break;
+      case TabStripModelChange::RemoveReason::kInsertedIntoOtherTabStrip:
+        reason_str = "Moved to other TabStrip";
+        break;
+    }
+
+    LOG(INFO) << "[Tab] TAB_REMOVED"
+              << " | Index: " << removed_tab.index << " | URL: " << url
+              << " | Reason: " << reason_str
+              << " | Remaining Tabs: " << tab_strip_model_->count();
+  }
+}
+
+void TabEventCollector::TabStripObserver::LogTabMoved(
+    const TabStripModelChange::Move* move) {
+  std::string url =
+      privacy_filter_->FilterUrl(move->contents->GetVisibleURL().spec());
+
+  LOG(INFO) << "[Tab] TAB_MOVED"
+            << " | From Index: " << move->from_index
+            << " | To Index: " << move->to_index << " | URL: " << url;
+}
+
+void TabEventCollector::TabStripObserver::LogTabReplaced(
+    const TabStripModelChange::Replace* replace) {
+  std::string old_url = privacy_filter_->FilterUrl(
+      replace->old_contents->GetVisibleURL().spec());
+  std::string new_url = privacy_filter_->FilterUrl(
+      replace->new_contents->GetVisibleURL().spec());
+
+  LOG(INFO) << "[Tab] TAB_REPLACED"
+            << " | Index: " << replace->index << " | Old URL: " << old_url
+            << " | New URL: " << new_url
+            << " | Reason: Prerender Activation";
+}
+
+void TabEventCollector::TabStripObserver::LogTabActivation(
+    const TabStripSelectionChange& selection) {
+  std::string old_url;
+  if (selection.old_contents) {
+    old_url = privacy_filter_->FilterUrl(
+        selection.old_contents->GetVisibleURL().spec());
+  } else {
+    old_url = "(none)";
+  }
+
+  std::string new_url;
+  std::string new_title;
+  if (selection.new_contents) {
+    new_url = privacy_filter_->FilterUrl(
+        selection.new_contents->GetVisibleURL().spec());
+    new_title = privacy_filter_->FilterTitle(
+        base::UTF16ToUTF8(selection.new_contents->GetTitle()));
+  } else {
+    new_url = "(none)";
+    new_title = "(none)";
+  }
+
+  std::string reason_str = "Unknown";
+  if (selection.reason & TabStripModelObserver::CHANGE_REASON_USER_GESTURE) {
+    reason_str = "User Gesture";
+  } else if (selection.reason &
+             TabStripModelObserver::CHANGE_REASON_REPLACED) {
+    reason_str = "Replaced";
+  } else if (selection.reason == TabStripModelObserver::CHANGE_REASON_NONE) {
+    reason_str = "Programmatic";
+  }
+
+  LOG(INFO) << "[Tab] TAB_ACTIVATED"
+            << " | Previous URL: " << old_url << " | New URL: " << new_url
+            << " | New Title: " << new_title << " | Reason: " << reason_str;
+}
+
+void TabEventCollector::TabStripObserver::LogTabChanged(
+    content::WebContents* contents,
+    int index,
+    TabChangeType change_type) {
+  std::string url =
+      privacy_filter_->FilterUrl(contents->GetVisibleURL().spec());
+  std::string title =
+      privacy_filter_->FilterTitle(base::UTF16ToUTF8(contents->GetTitle()));
+
+  std::string change_type_str;
+  switch (change_type) {
+    case TabChangeType::kAll:
+      change_type_str = "All";
+      break;
+    case TabChangeType::kLoadingOnly:
+      change_type_str = "Loading";
+      break;
+  }
+
+  LOG(INFO) << "[Tab] TAB_CHANGED"
+            << " | Index: " << index << " | URL: " << url
+            << " | Title: " << title << " | Change Type: " << change_type_str;
+}
+
+void TabEventCollector::TabStripObserver::LogTabPinnedStateChanged(
+    content::WebContents* contents,
+    int index,
+    bool pinned) {
+  std::string url =
+      privacy_filter_->FilterUrl(contents->GetVisibleURL().spec());
+
+  LOG(INFO) << "[Tab] TAB_PINNED_STATE_CHANGED"
+            << " | Index: " << index << " | URL: " << url
+            << " | Pinned: " << (pinned ? "Yes" : "No");
+}
+
+void TabEventCollector::TabStripObserver::LogTabGroupChange(
+    const TabGroupChange& change) {
+  std::string change_type_str;
+  switch (change.type) {
+    case TabGroupChange::kCreated:
+      change_type_str = "Created";
+      break;
+    case TabGroupChange::kEditorOpened:
+      change_type_str = "Editor Opened";
+      break;
+    case TabGroupChange::kContentsChanged:
+      change_type_str = "Contents Changed";
+      break;
+    case TabGroupChange::kVisualsChanged:
+      change_type_str = "Visuals Changed";
+      break;
+    case TabGroupChange::kMoved:
+      change_type_str = "Moved";
+      break;
+    case TabGroupChange::kClosed:
+      change_type_str = "Closed";
+      break;
+  }
+
+  LOG(INFO) << "[Tab] TAB_GROUP_CHANGED"
+            << " | Group ID: " << change.group.ToString()
+            << " | Change Type: " << change_type_str;
+}
+
+std::string TabEventCollector::TabStripObserver::GetTabInfo(
+    content::WebContents* contents,
+    int index) {
+  std::string url =
+      privacy_filter_->FilterUrl(contents->GetVisibleURL().spec());
+  std::string title =
+      privacy_filter_->FilterTitle(base::UTF16ToUTF8(contents->GetTitle()));
+
+  return "Index: " + base::NumberToString(index) + ", URL: " + url +
+         ", Title: " + title;
+}
+#endif  // !BUILDFLAG(IS_ANDROID)
+
+#if BUILDFLAG(IS_ANDROID)
+// Android implementation
+void TabEventCollector::ObserveTabModel(TabModel* tab_model) {
+  if (!tab_model) {
+    return;
+  }
+
+  // Check if already observing
+  if (android_observers_.find(tab_model) != android_observers_.end()) {
+    return;
+  }
+
+  auto observer = std::make_unique<TabModelObserverImpl>(
+      tab_model, privacy_filter_, navigation_collector_);
+  android_observers_[tab_model] = std::move(observer);
+
+  LOG(ERROR) << "[TabCollector] Now observing TabModel with "
+            << tab_model->GetTabCount() << " tabs";
+}
+
+void TabEventCollector::StopObservingTabModel(TabModel* tab_model) {
+  auto it = android_observers_.find(tab_model);
+  if (it != android_observers_.end()) {
+    LOG(ERROR) << "[TabCollector] Stopped observing TabModel";
+    android_observers_.erase(it);
+  }
+}
+
+void TabEventCollector::Shutdown() {
+  LOG(ERROR) << "[TabCollector] Shutting down (Android)";
+  android_observers_.clear();
+}
+
+// Android TabModelObserverImpl implementation
+
+TabEventCollector::TabModelObserverImpl::TabModelObserverImpl(
+    TabModel* tab_model,
+    PrivacyFilter* privacy_filter,
+    NavigationEventCollector* navigation_collector)
+    : tab_model_(tab_model),
+      privacy_filter_(privacy_filter),
+      navigation_collector_(navigation_collector) {
+  tab_model_->AddObserver(this);
+}
+
+TabEventCollector::TabModelObserverImpl::~TabModelObserverImpl() {
+  if (tab_model_) {
+    tab_model_->RemoveObserver(this);
+  }
+}
+
+void TabEventCollector::TabModelObserverImpl::DidSelectTab(
+    TabAndroid* tab,
+    TabModel::TabSelectionType type,
+    int last_id) {
+  content::WebContents* web_contents = tab->web_contents();
+  if (!web_contents) {
+    return;
+  }
+
+  // ⭐ CRITICAL: Attach navigation observer to this WebContents
+  navigation_collector_->ObserveWebContents(web_contents);
+
+  std::string url =
+      privacy_filter_->FilterUrl(web_contents->GetVisibleURL().spec());
+  std::string title = privacy_filter_->FilterTitle(
+      base::UTF16ToUTF8(web_contents->GetTitle()));
+
+  std::string selection_type_str;
+  switch (type) {
+    case TabModel::TabSelectionType::FROM_USER:
+      selection_type_str = "User Gesture";
+      break;
+    case TabModel::TabSelectionType::FROM_NEW:
+      selection_type_str = "New Tab";
+      break;
+    case TabModel::TabSelectionType::FROM_CLOSE:
+      selection_type_str = "From Close";
+      break;
+    case TabModel::TabSelectionType::FROM_EXIT:
+      selection_type_str = "From Exit";
+      break;
+    case TabModel::TabSelectionType::FROM_UNDO:
+      selection_type_str = "From Undo";
+      break;
+    case TabModel::TabSelectionType::FROM_OMNIBOX:
+      selection_type_str = "From Omnibox";
+      break;
+    case TabModel::TabSelectionType::SIZE:
+      selection_type_str = "Unknown";
+      break;
+  }
+
+  LOG(ERROR) << "[Tab] 🔵 TAB_SELECTED (Android)"
+            << " | Tab ID: " << tab->GetAndroidId() << " | URL: " << url
+            << " | Title: " << title << " | Type: " << selection_type_str
+            << " | Last Tab ID: " << last_id;
+}
+
+void TabEventCollector::TabModelObserverImpl::WillCloseTab(TabAndroid* tab) {
+  content::WebContents* web_contents = tab->web_contents();
+  if (!web_contents) {
+    return;
+  }
+
+  std::string url =
+      privacy_filter_->FilterUrl(web_contents->GetVisibleURL().spec());
+
+  LOG(ERROR) << "[Tab] ❌ TAB_CLOSING (Android)"
+            << " | Tab ID: " << tab->GetAndroidId() << " | URL: " << url;
+}
+
+void TabEventCollector::TabModelObserverImpl::DidAddTab(TabAndroid* tab,
+                                                         TabModel::TabLaunchType type) {
+  content::WebContents* web_contents = tab->web_contents();
+  if (!web_contents) {
+    return;
+  }
+
+  // ⭐ CRITICAL: Attach navigation observer to this new WebContents
+  navigation_collector_->ObserveWebContents(web_contents);
+
+  std::string url =
+      privacy_filter_->FilterUrl(web_contents->GetVisibleURL().spec());
+
+  LOG(ERROR) << "[Tab] ➕ TAB_ADDED (Android)"
+            << " | Tab ID: " << tab->GetAndroidId() << " | URL: " << url
+            << " | Launch Type: " << static_cast<int>(type)
+            << " | Total Tabs: " << tab_model_->GetTabCount();
+}
+
+void TabEventCollector::TabModelObserverImpl::DidMoveTab(TabAndroid* tab,
+                                                           int new_index,
+                                                           int old_index) {
+  content::WebContents* web_contents = tab->web_contents();
+  if (!web_contents) {
+    return;
+  }
+
+  std::string url =
+      privacy_filter_->FilterUrl(web_contents->GetVisibleURL().spec());
+
+  LOG(ERROR) << "[Tab] ↔️ TAB_MOVED (Android)"
+            << " | Tab ID: " << tab->GetAndroidId() << " | From: " << old_index
+            << " | To: " << new_index << " | URL: " << url;
+}
+#endif  // BUILDFLAG(IS_ANDROID)
+
+}  // namespace activity_tracking
+

--- a/src/chrome/browser/activity_tracking/tab_event_collector.h
+++ b/src/chrome/browser/activity_tracking/tab_event_collector.h
@@ -1,0 +1,152 @@
+// Copyright 2024 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef CHROME_BROWSER_ACTIVITY_TRACKING_TAB_EVENT_COLLECTOR_H_
+#define CHROME_BROWSER_ACTIVITY_TRACKING_TAB_EVENT_COLLECTOR_H_
+
+#include <map>
+#include <memory>
+
+#include "base/memory/raw_ptr.h"
+#include "build/build_config.h"
+
+#if !BUILDFLAG(IS_ANDROID)
+#include "chrome/browser/ui/tabs/tab_strip_model_observer.h"
+class TabStripModel;
+#else
+#include "chrome/browser/ui/android/tab_model/tab_model_observer.h"
+class TabModel;
+#endif
+
+namespace content {
+class WebContents;
+}
+
+namespace activity_tracking {
+
+class NavigationEventCollector;
+class PrivacyFilter;
+
+// TabEventCollector observes tab operations across all TabStripModels
+// and logs detailed information about each tab event.
+//
+// This class tracks:
+// - Tab creation/insertion
+// - Tab removal/closure
+// - Tab activation/switching
+// - Tab moves/reordering
+// - Tab replacement (prerendering)
+// - Tab grouping operations
+class TabEventCollector {
+ public:
+  explicit TabEventCollector(PrivacyFilter* privacy_filter, 
+                             NavigationEventCollector* navigation_collector);
+  ~TabEventCollector();
+
+  TabEventCollector(const TabEventCollector&) = delete;
+  TabEventCollector& operator=(const TabEventCollector&) = delete;
+
+#if !BUILDFLAG(IS_ANDROID)
+  // Start observing a TabStripModel (Desktop)
+  void ObserveTabStripModel(TabStripModel* tab_strip_model);
+
+  // Stop observing a specific TabStripModel (Desktop)
+  void StopObservingTabStripModel(TabStripModel* tab_strip_model);
+#else
+  // Start observing a TabModel (Android)
+  void ObserveTabModel(TabModel* tab_model);
+
+  // Stop observing a specific TabModel (Android)
+  void StopObservingTabModel(TabModel* tab_model);
+#endif
+
+  // Stop all observations and clean up
+  void Shutdown();
+
+ private:
+#if !BUILDFLAG(IS_ANDROID)
+  // Per-TabStripModel observer that tracks tab events (Desktop)
+  class TabStripObserver : public TabStripModelObserver {
+   public:
+    TabStripObserver(TabStripModel* tab_strip_model,
+                     PrivacyFilter* privacy_filter);
+    ~TabStripObserver() override;
+
+    // TabStripModelObserver implementation:
+    void OnTabStripModelChanged(
+        TabStripModel* tab_strip_model,
+        const TabStripModelChange& change,
+        const TabStripSelectionChange& selection) override;
+
+    void TabChangedAt(content::WebContents* contents,
+                      int index,
+                      TabChangeType change_type) override;
+
+    void TabPinnedStateChanged(TabStripModel* tab_strip_model,
+                               content::WebContents* contents,
+                               int index) override;
+
+    void TabGroupedStateChanged(std::optional<tab_groups::TabGroupId> group,
+                                content::WebContents* contents,
+                                int index) override;
+
+    void OnTabGroupChanged(const TabGroupChange& change) override;
+
+   private:
+    void LogTabInserted(const TabStripModelChange::Insert* insert);
+    void LogTabRemoved(const TabStripModelChange::Remove* remove);
+    void LogTabMoved(const TabStripModelChange::Move* move);
+    void LogTabReplaced(const TabStripModelChange::Replace* replace);
+    void LogTabActivation(const TabStripSelectionChange& selection);
+    void LogTabChanged(content::WebContents* contents,
+                       int index,
+                       TabChangeType change_type);
+    void LogTabPinnedStateChanged(content::WebContents* contents,
+                                  int index,
+                                  bool pinned);
+    void LogTabGroupChange(const TabGroupChange& change);
+
+    std::string GetTabInfo(content::WebContents* contents, int index);
+
+    raw_ptr<TabStripModel> tab_strip_model_;
+    raw_ptr<PrivacyFilter> privacy_filter_;
+  };
+
+  // Map of TabStripModel to their observers
+  std::map<raw_ptr<TabStripModel>, std::unique_ptr<TabStripObserver>>
+      observers_;
+#else
+  // Per-TabModel observer that tracks tab events (Android)
+  class TabModelObserverImpl : public TabModelObserver {
+   public:
+    TabModelObserverImpl(TabModel* tab_model, 
+                        PrivacyFilter* privacy_filter,
+                        NavigationEventCollector* navigation_collector);
+    ~TabModelObserverImpl() override;
+
+    // TabModelObserver implementation:
+    void DidSelectTab(TabAndroid* tab, TabModel::TabSelectionType type, int last_id) override;
+    void WillCloseTab(TabAndroid* tab) override;
+    void DidAddTab(TabAndroid* tab, TabModel::TabLaunchType type) override;
+    void DidMoveTab(TabAndroid* tab, int new_index, int old_index) override;
+
+   private:
+    raw_ptr<TabModel> tab_model_;
+    raw_ptr<PrivacyFilter> privacy_filter_;
+    raw_ptr<NavigationEventCollector> navigation_collector_;
+  };
+
+  // Map of TabModel to their observers
+  std::map<raw_ptr<TabModel>, std::unique_ptr<TabModelObserverImpl>>
+      android_observers_;
+#endif
+
+  raw_ptr<PrivacyFilter> privacy_filter_;
+  raw_ptr<NavigationEventCollector> navigation_collector_;
+};
+
+}  // namespace activity_tracking
+
+#endif  // CHROME_BROWSER_ACTIVITY_TRACKING_TAB_EVENT_COLLECTOR_H_
+

--- a/src/chrome/browser/profiles/chrome_browser_main_extra_parts_profiles.cc
+++ b/src/chrome/browser/profiles/chrome_browser_main_extra_parts_profiles.cc
@@ -11,6 +11,7 @@
 #include "build/build_config.h"
 #include "build/chromeos_buildflags.h"
 #include "chrome/browser/accessibility/accessibility_labels_service_factory.h"
+#include "chrome/browser/activity_tracking/activity_tracking_service_factory.h"
 #include "chrome/browser/accessibility/page_colors_factory.h"
 #include "chrome/browser/affiliations/affiliation_service_factory.h"
 #include "chrome/browser/autocomplete/autocomplete_classifier_factory.h"
@@ -583,6 +584,7 @@ void ChromeBrowserMainExtraPartsProfiles::
   AcceptLanguagesServiceFactory::GetInstance();
   AccessibilityLabelsServiceFactory::GetInstance();
   AccountBookmarkSyncServiceFactory::GetInstance();
+  activity_tracking::ActivityTrackingServiceFactory::GetInstance();
   AccountConsistencyModeManagerFactory::GetInstance();
   AccountInvestigatorFactory::GetInstance();
   AccountPasswordStoreFactory::GetInstance();


### PR DESCRIPTION
### **User description**
In - Progress


___

### **PR Type**
Enhancement


___

### **Description**
- Implement comprehensive activity tracking system with OpenTelemetry & Splunk integration

- Add navigation event collection with privacy filtering and data export capabilities

- Create tab event tracking for desktop and Android platforms with observer pattern

- Integrate Splunk Observability Cloud exporter for telemetry data transmission

- Update FAB behavior to open Wootz AI extension instead of chat menu


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Browser Activity"] --> B["ActivityTrackingService"]
  B --> C["NavigationEventCollector"]
  B --> D["TabEventCollector"]
  C --> E["PrivacyFilter"]
  D --> E
  E --> F["ActivityDataStore"]
  F --> G["SplunkObservabilityExporter"]
  G --> H["Splunk Cloud SignalFx"]
  C --> I["OpenTelemetry Format"]
  I --> G
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>16 files</summary><table>
<tr>
  <td><strong>activity_data_store.h</strong><dd><code>Activity data storage and OpenTelemetry export interface</code>&nbsp; </dd></td>
  <td><a href="https://github.com/wootzapp/wootz-browser/pull/385/files#diff-1224deea67b541424617f83e29d00078087c6a38adbbc14925382fc10e76abc1">+75/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>activity_data_store.cc</strong><dd><code>In-memory event buffering with OpenTelemetry JSON conversion</code></dd></td>
  <td><a href="https://github.com/wootzapp/wootz-browser/pull/385/files#diff-d03b2676358bcbeba06856c61c009e1e60e519cce08a86647ab6f4e1bf222cdf">+83/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>activity_tracking_service.h</strong><dd><code>Main coordination service for activity tracking across platforms</code></dd></td>
  <td><a href="https://github.com/wootzapp/wootz-browser/pull/385/files#diff-5c282ef9f4664a60815777a32801e7e1b8d5fcb3ad867e60a97f8d49e770b494">+123/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>activity_tracking_service.cc</strong><dd><code>Service initialization with platform-specific browser/tab observation</code></dd></td>
  <td><a href="https://github.com/wootzapp/wootz-browser/pull/385/files#diff-4da78d5406eff26469436c575247abe49b33de993095ea1c1312fdb233464608">+205/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>activity_tracking_service_factory.h</strong><dd><code>KeyedService factory for per-profile service instantiation</code></dd></td>
  <td><a href="https://github.com/wootzapp/wootz-browser/pull/385/files#diff-684e275be3e0b26687893f34ad69d0a31af4e3d175389d3ee71e5f09d2a1296f">+44/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>activity_tracking_service_factory.cc</strong><dd><code>Factory implementation following Chromium KeyedService pattern</code></dd></td>
  <td><a href="https://github.com/wootzapp/wootz-browser/pull/385/files#diff-c3dedada8e03fb512168a2cb789c9c4197bcc7c90793cb5ee99792cf250d043c">+50/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>navigation_event_collector.h</strong><dd><code>Navigation event observation and OpenTelemetry log format conversion</code></dd></td>
  <td><a href="https://github.com/wootzapp/wootz-browser/pull/385/files#diff-1987c1d58d47c485f04b77d26f6b9f063a281fe01d9e72d70d3f5d187a080ea8">+139/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>navigation_event_collector.cc</strong><dd><code>Per-WebContents navigation tracking with timing and state management</code></dd></td>
  <td><a href="https://github.com/wootzapp/wootz-browser/pull/385/files#diff-14bcbd1b072abdce0cf2642ad46ab8fe2e7492d9d0e080a29e31627f375916b0">+348/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>privacy_filter.h</strong><dd><code>Privacy-aware URL and title filtering for sensitive data protection</code></dd></td>
  <td><a href="https://github.com/wootzapp/wootz-browser/pull/385/files#diff-179de9e5609340db249ad39cb912f807e88da95c87b36738caf0da44e0d5b4fb">+59/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>privacy_filter.cc</strong><dd><code>Sensitive parameter removal and incognito mode redaction logic</code></dd></td>
  <td><a href="https://github.com/wootzapp/wootz-browser/pull/385/files#diff-e6f66fccbfcf6639564912b7612440e6b5131b83d8eb3317d041f3b3a1c16283">+137/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>splunk_observability_exporter.h</strong><dd><code>Splunk SignalFx API integration with event and metrics export</code></dd></td>
  <td><a href="https://github.com/wootzapp/wootz-browser/pull/385/files#diff-864f6ca76665010da595ab602f03a2a56fe3babc0ee2e4bb5c68660f47815f89">+94/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>splunk_observability_exporter.cc</strong><dd><code>OpenTelemetry to SignalFx format conversion and HTTP network export</code></dd></td>
  <td><a href="https://github.com/wootzapp/wootz-browser/pull/385/files#diff-63fce1b2499449ac9068839bb0a754019e1164116fca5db9582bad6266f8af0f">+397/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>tab_event_collector.h</strong><dd><code>Tab operation tracking with platform-specific desktop and Android </code><br><code>support</code></dd></td>
  <td><a href="https://github.com/wootzapp/wootz-browser/pull/385/files#diff-87004183728722158f7e04e085f391d2b989ce67f423d278040325f0c965b84e">+152/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>tab_event_collector.cc</strong><dd><code>TabStripModel and TabModel observers for tab lifecycle event logging</code></dd></td>
  <td><a href="https://github.com/wootzapp/wootz-browser/pull/385/files#diff-0bc19da82d0a32aed0e4ee310bf3ff0d61949bc3733b5a221fb249f4877d3ddb">+472/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>chrome_browser_main_extra_parts_profiles.cc</strong><dd><code>Register ActivityTrackingServiceFactory in browser initialization</code></dd></td>
  <td><a href="https://github.com/wootzapp/wootz-browser/pull/385/files#diff-66efd4f8082677a76c9e55b29d516ee565f2b9b0572e64d91ecf0d9a72ba41d4">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ChromeActivity.java</strong><dd><code>Change FAB behavior to open Wootz AI extension on tap</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/wootzapp/wootz-browser/pull/385/files#diff-c8acd06c7d46dc25f58ba07fb743c8b5d67d7da310275e70e1cdd7abe1bbdb36">+28/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>BUILD.gn</strong><dd><code>Build configuration for activity tracking component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/wootzapp/wootz-browser/pull/385/files#diff-54b9a12d18f4684d778bb9b5b7a2bc0ecb9c708c817c6390daaa95ea6ecc9825">+42/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>BUILD.gn</strong><dd><code>Add activity_tracking dependency to browser target</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/wootzapp/wootz-browser/pull/385/files#diff-032fb0f3fe356194a508f998b52874719c47300911aa2be3ea434eb26c322126">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>config.gni</strong><dd><code>Update Android version code and name for release</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/wootzapp/wootz-browser/pull/385/files#diff-80421383edd2d63a6a76679bee5bfea7363eaaf812df711a3513853f246fb4cc">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

